### PR TITLE
some backports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,26 @@
 buildscript {
 	repositories {
 		maven {
+			name 'Quilt Releases'
+			url 'https://maven.quiltmc.org/repository/release/'
+		}
+		maven {
+			name 'Quilt Snapshot Repository'
+			url 'https://maven.quiltmc.org/repository/snapshot/'
+		}
+		maven {
 			name "Fabric Repository"
 			url 'https://maven.fabricmc.net'
+		}
+		maven {
+			// Vineflower snapshots
+			url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 		}
 		mavenCentral()
 		mavenLocal()
 	}
 	dependencies {
-		classpath "cuchaz:enigma-cli:${project.enigma_version}"
+		classpath "org.quiltmc:enigma-cli:${project.enigma_version}"
 		classpath "net.fabricmc:stitch:${project.stitch_version}"
 		classpath "net.fabricmc:name-proposal:${project.name_proposal_version}"
 	}
@@ -45,12 +57,24 @@ if (ENV.BRANCH_NAME) {
 repositories {
 	mavenCentral()
 	maven {
+		name "Quilt Repository"
+		url "https://maven.quiltmc.org/repository/release"
+	}
+	maven {
 		name "Fabric Repository"
 		url 'https://maven.fabricmc.net'
 	}
 	maven {
 		name "Mojang"
 		url 'https://libraries.minecraft.net/'
+	}
+	maven {
+		name "Quilt Snapshot Repository"
+		url "https://maven.quiltmc.org/repository/snapshot"
+	}
+	maven {
+		// Vineflower snapshots
+		url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 	}
 	mavenLocal()
 }
@@ -75,7 +99,7 @@ configurations {
 def unpickMetaFile = file("unpick-definitions/unpick.json")
 
 dependencies {
-	enigmaRuntime "cuchaz:enigma-swing:${project.enigma_version}"
+	enigmaRuntime "org.quiltmc:enigma-swing:${project.enigma_version}"
 	enigmaRuntime "net.fabricmc:name-proposal:${project.name_proposal_version}"
 	javadocClasspath "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
 	javadocClasspath "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
@@ -723,7 +747,7 @@ abstract class EnigmaTask extends JavaExec {
 		args mappings.get().absolutePath
 		args '-profile'
 		args 'enigma_profile.json'
-		jvmArgs "-Xmx2048m"
+//		jvmArgs "-Xmx2048m"
 		super.exec()
 	}
 }

--- a/filament/build.gradle
+++ b/filament/build.gradle
@@ -23,14 +23,34 @@ repositories {
 		name "Fabric Repository"
 		url 'https://maven.fabricmc.net'
 	}
+	maven {
+		name "Quilt Repository"
+		url "https://maven.quiltmc.org/repository/release"
+	}
+	maven {
+		name "Fabric Repository"
+		url 'https://maven.fabricmc.net'
+	}
+	maven {
+		name "Mojang"
+		url 'https://libraries.minecraft.net/'
+	}
+	maven {
+		name "Quilt Snapshot Repository"
+		url "https://maven.quiltmc.org/repository/snapshot"
+	}
+	maven {
+		// Vineflower snapshots
+		url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+	}
 	mavenCentral()
 }
 
 dependencies {
 	implementation "org.ow2.asm:asm:${properties.asm_version}"
 	implementation "org.ow2.asm:asm-tree:${properties.asm_version}"
-	implementation "cuchaz:enigma:$properties.enigma_version"
-	implementation "cuchaz:enigma-cli:$properties.enigma_version"
+	implementation "org.quiltmc:enigma:$properties.enigma_version"
+	implementation "org.quiltmc:enigma-cli:$properties.enigma_version"
 	implementation "net.fabricmc.unpick:unpick:$properties.unpick_version"
 	implementation "net.fabricmc.unpick:unpick-format-utils:$properties.unpick_version"
 	implementation "net.fabricmc.unpick:unpick-cli:$properties.unpick_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
-enigma_version=2.3.0
-stitch_version=0.6.1
+enigma_version=1.9.1
+stitch_version=0.6.2
 unpick_version=2.3.0
 cfr_version=0.1.1
 name_proposal_version=0.1.4

--- a/mappings/com/mojang/realmsclient/client/RealmsError.mapping
+++ b/mappings/com/mojang/realmsclient/client/RealmsError.mapping
@@ -2,7 +2,5 @@ CLASS net/minecraft/class_4345 com/mojang/realmsclient/client/RealmsError
 	FIELD field_19593 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_19594 errorMessage Ljava/lang/String;
 	FIELD field_19595 errorCode I
-	METHOD <init> (Ljava/lang/String;)V
-		ARG 1 error
 	METHOD method_21036 getErrorMessage ()Ljava/lang/String;
 	METHOD method_21037 getErrorCode ()I

--- a/mappings/net/minecraft/Bootstrap.mapping
+++ b/mappings/net/minecraft/Bootstrap.mapping
@@ -11,3 +11,4 @@ CLASS net/minecraft/class_2966 net/minecraft/Bootstrap
 	METHOD method_12852 setOutputStreams ()V
 	METHOD method_17597 getMissingTranslations ()Ljava/util/Set;
 	METHOD method_17598 logMissing ()V
+	METHOD method_27732 collectMissingGameRuleTranslations (Ljava/util/Set;)V

--- a/mappings/net/minecraft/MinecraftVersion.mapping
+++ b/mappings/net/minecraft/MinecraftVersion.mapping
@@ -8,4 +8,5 @@ CLASS net/minecraft/class_3797 net/minecraft/MinecraftVersion
 	FIELD field_16739 buildTime Ljava/util/Date;
 	FIELD field_16740 releaseTarget Ljava/lang/String;
 	FIELD field_16741 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_25319 gameVersion Lcom/mojang/bridge/game/GameVersion;
 	METHOD method_16672 create ()Lcom/mojang/bridge/game/GameVersion;

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_1125 isDevelopment Z
 	FIELD field_1126 INVALID_CHARS_LEVEL_NAME [C
 	FIELD field_16742 gameVersion Lcom/mojang/bridge/game/GameVersion;
+	FIELD field_22251 Redlime J
+	FIELD field_25135 useChoiceTypeRegistrations Z
 	METHOD method_16673 getGameVersion ()Lcom/mojang/bridge/game/GameVersion;
 	METHOD method_643 isValidChar (C)Z
 		ARG 0 chr

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -526,6 +526,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_26234 isFullCube (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 			ARG 1 world
 			ARG 2 pos
+		METHOD method_27851 isIn (Lnet/minecraft/class_3494;Ljava/util/function/Predicate;)Z
 		METHOD method_27852 isOf (Lnet/minecraft/class_2248;)Z
 			ARG 1 block
 		METHOD method_29291 isToolRequired ()Z

--- a/mappings/net/minecraft/block/CampfireBlock.mapping
+++ b/mappings/net/minecraft/block/CampfireBlock.mapping
@@ -28,3 +28,7 @@ CLASS net/minecraft/class_3922 net/minecraft/block/CampfireBlock
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
+	METHOD method_30034 (Lnet/minecraft/class_4970$class_4971;)Z
+		ARG 0 blockState
+	METHOD method_30035 canBeLit (Lnet/minecraft/class_2680;)Z
+		ARG 0 state

--- a/mappings/net/minecraft/block/pattern/BlockPattern.mapping
+++ b/mappings/net/minecraft/block/pattern/BlockPattern.mapping
@@ -57,6 +57,7 @@ CLASS net/minecraft/class_2700 net/minecraft/block/pattern/BlockPattern
 		METHOD method_11719 getForwards ()Lnet/minecraft/class_2350;
 		METHOD method_11720 getHeight ()I
 		METHOD method_18478 getTeleportTarget (Lnet/minecraft/class_2350;Lnet/minecraft/class_2338;DLnet/minecraft/class_243;D)Lnet/minecraft/class_2700$class_4297;
+			ARG 2 pos
 	CLASS class_4297 TeleportTarget
 		FIELD field_19281 pos Lnet/minecraft/class_243;
 		FIELD field_19282 velocity Lnet/minecraft/class_243;

--- a/mappings/net/minecraft/client/Keyboard.mapping
+++ b/mappings/net/minecraft/client/Keyboard.mapping
@@ -10,9 +10,13 @@ CLASS net/minecraft/class_309 net/minecraft/client/Keyboard
 		ARG 1 client
 	METHOD method_1455 setClipboard (Ljava/lang/String;)V
 	METHOD method_1456 debugError (Ljava/lang/String;[Ljava/lang/Object;)V
+		ARG 1 key
+		ARG 2 args
 	METHOD method_1457 onChar (JII)V
 		ARG 1 window
 	METHOD method_1459 debugWarn (Ljava/lang/String;[Ljava/lang/Object;)V
+		ARG 1 key
+		ARG 2 args
 	METHOD method_1460 getClipboard ()Ljava/lang/String;
 	METHOD method_1462 enableRepeatEvents (Z)V
 		ARG 1 repeatEvents

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -99,6 +99,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_24211 UNICODE_FONT_ID Lnet/minecraft/class_2960;
 	FIELD field_25033 multiplayerEnabled Z
 	FIELD field_25034 onlineChatEnabled Z
+	FIELD field_25671 videoWarningManager Lnet/minecraft/class_5407;
 	METHOD <init> (Lnet/minecraft/class_542;)V
 		ARG 1 args
 	METHOD method_1476 checkIs64Bit ()Z
@@ -164,6 +165,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_1547 getVersionType ()Ljava/lang/String;
 	METHOD method_1548 getSession ()Lnet/minecraft/class_320;
 	METHOD method_1549 getSpriteAtlas (Lnet/minecraft/class_2960;)Ljava/util/function/Function;
+		ARG 1 id
 	METHOD method_1551 getInstance ()Lnet/minecraft/class_310;
 	METHOD method_1552 getSnooper ()Lnet/minecraft/class_1276;
 	METHOD method_1554 getBakedModelManager ()Lnet/minecraft/class_1092;
@@ -224,6 +226,12 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_22683 getWindow ()Lnet/minecraft/class_1041;
 	METHOD method_22940 getBufferBuilders ()Lnet/minecraft/class_4599;
 	METHOD method_24038 createResourcePackProfile (Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/class_3262;Lnet/minecraft/class_3272;Lnet/minecraft/class_3288$class_3289;Lnet/minecraft/class_5352;)Lnet/minecraft/class_1075;
+		ARG 0 name
+		ARG 1 alwaysEnabled
+		ARG 2 packFactory
+		ARG 4 metadata
+		ARG 5 direction
+		ARG 6 source
 	METHOD method_24041 resetMipmapLevels (I)V
 		ARG 1 mipmapLevels
 	METHOD method_24042 createV3ResourcePackFactory (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;

--- a/mappings/net/minecraft/client/MinecraftClientGame.mapping
+++ b/mappings/net/minecraft/client/MinecraftClientGame.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_3799 net/minecraft/client/MinecraftClientGame
 	FIELD field_16757 client Lnet/minecraft/class_310;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
+	METHOD getCurrentSession ()Lcom/mojang/bridge/game/GameSession;
 	METHOD method_16687 onStartGameSession ()V
 	METHOD method_16688 onLeaveGameSession ()V
 	METHOD setSessionEventListener (Lcom/mojang/bridge/launcher/SessionEventListener;)V

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -200,3 +200,4 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 4 x
 		ARG 5 y
 		ARG 6 color
+	METHOD method_29343 drawWithOutline (IILjava/util/function/BiConsumer;)V

--- a/mappings/net/minecraft/client/gui/screen/AddServerScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/AddServerScreen.mapping
@@ -15,3 +15,6 @@ CLASS net/minecraft/class_422 net/minecraft/client/gui/screen/AddServerScreen
 		ARG 1 text
 	METHOD method_2172 addAndClose ()V
 	METHOD method_24183 updateButtonActiveState ()V
+	METHOD method_25410 (Lnet/minecraft/class_310;II)V
+	METHOD method_27570 (Lnet/minecraft/class_642$class_643;)Lnet/minecraft/class_2561;
+		ARG 0 state

--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 	FIELD field_21616 commandSuggestor Lnet/minecraft/class_4717;
 	FIELD field_2382 chatField Lnet/minecraft/class_342;
 	FIELD field_2387 messageHistorySize I
+	FIELD field_2389 chatLastMessage Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 originalChatText
 	METHOD method_2108 setText (Ljava/lang/String;)V

--- a/mappings/net/minecraft/client/gui/screen/ConfirmScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConfirmScreen.mapping
@@ -13,4 +13,9 @@ CLASS net/minecraft/class_410 net/minecraft/client/gui/screen/ConfirmScreen
 		ARG 1 callback
 		ARG 2 title
 		ARG 3 message
+		ARG 4 yesText
+		ARG 5 noText
 	METHOD method_2125 disableButtons (I)V
+		ARG 1 delay
+	METHOD method_25393 ()V
+	METHOD method_25394 (Lnet/minecraft/class_4587;IIF)V

--- a/mappings/net/minecraft/client/gui/screen/CreditsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CreditsScreen.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_445 net/minecraft/client/gui/screen/CreditsScreen
+	FIELD field_24260 OBSFUCATION_PLACEHOLDER Ljava/lang/String;
+	FIELD field_24261 centeredLines Lit/unimi/dsi/fastutil/ints/IntSet;
 	FIELD field_2626 MINECRAFT_TITLE_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_2627 endCredits Z
 	FIELD field_2628 time F
@@ -17,3 +19,5 @@ CLASS net/minecraft/class_445 net/minecraft/client/gui/screen/CreditsScreen
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 tickDelta
+	METHOD method_25394 (Lnet/minecraft/class_4587;IIF)V
+	METHOD method_25426 ()V

--- a/mappings/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.mapping
@@ -5,5 +5,26 @@ CLASS net/minecraft/class_413 net/minecraft/client/gui/screen/CustomizeFlatLevel
 	FIELD field_2422 parent Lnet/minecraft/class_437;
 	FIELD field_2424 layers Lnet/minecraft/class_413$class_4192;
 	FIELD field_2425 heightText Lnet/minecraft/class_2561;
+	FIELD field_24565 configConsumer Ljava/util/function/Consumer;
+	METHOD <init> (Lnet/minecraft/class_437;Ljava/util/function/Consumer;Lnet/minecraft/class_3232;)V
+		ARG 1 parent
+		ARG 2 configConsumer
+		ARG 3 config
+	METHOD method_20093 (Lnet/minecraft/class_4185;)V
+	METHOD method_25394 (Lnet/minecraft/class_4587;IIF)V
+	METHOD method_29054 (Lnet/minecraft/class_3232;)V
+		ARG 1 config
 	CLASS class_4192 SuperflatLayersListWidget
+		METHOD method_19372 ()V
+		METHOD method_20094 (Lnet/minecraft/class_413$class_4192$class_4193;)V
 		CLASS class_4193 SuperflatLayerItem
+			METHOD method_19373 (Lnet/minecraft/class_4587;II)V
+				ARG 1 matrices
+				ARG 2 x
+				ARG 3 y
+			METHOD method_19375 (Lnet/minecraft/class_4587;IILnet/minecraft/class_1799;)V
+				ARG 1 matrices
+				ARG 2 x
+				ARG 3 y
+				ARG 4 itemStack
+			METHOD method_25343 (Lnet/minecraft/class_4587;IIIIIIIZF)V

--- a/mappings/net/minecraft/client/gui/screen/DatapackFailureScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/DatapackFailureScreen.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_5346 net/minecraft/client/gui/screen/DatapackFailureScreen
 	FIELD field_25265 wrappedText Ljava/util/List;
+	FIELD field_25452 runServerInSafeMode Ljava/lang/Runnable;
+	METHOD method_25394 (Lnet/minecraft/class_4587;IIF)V

--- a/mappings/net/minecraft/client/gui/screen/FatalErrorScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/FatalErrorScreen.mapping
@@ -2,3 +2,4 @@ CLASS net/minecraft/class_421 net/minecraft/client/gui/screen/FatalErrorScreen
 	FIELD field_2467 message Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)V
 		ARG 1 title
+		ARG 2 message

--- a/mappings/net/minecraft/client/gui/screen/GameModeSelectionScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/GameModeSelectionScreen.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_5289 net/minecraft/client/gui/screen/GameModeSelection
 	FIELD field_24571 lastMouseY I
 	FIELD field_24572 mouseUsedForSelection Z
 	FIELD field_24573 gameModeButtons Ljava/util/List;
+	FIELD field_25454 SELECT_NEXT_TEXT Lnet/minecraft/class_2561;
 	METHOD method_28064 apply (Lnet/minecraft/class_310;Ljava/util/Optional;)V
 		ARG 0 client
 		ARG 1 gameMode

--- a/mappings/net/minecraft/client/gui/screen/LevelLoadingScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/LevelLoadingScreen.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/class_3928 net/minecraft/client/gui/screen/LevelLoadingScreen
 	FIELD field_17406 progressProvider Lnet/minecraft/class_3953;
 	FIELD field_17407 STATUS_TO_COLOR Lit/unimi/dsi/fastutil/objects/Object2IntMap;
+	FIELD field_19101 lastNarrationTime J
 	METHOD <init> (Lnet/minecraft/class_3953;)V
 		ARG 1 progressProvider
 	METHOD method_17537 (Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;)V
 		ARG 0 map
 	METHOD method_17538 drawChunkMap (Lnet/minecraft/class_4587;Lnet/minecraft/class_3953;IIII)V
+		ARG 0 matrices
+	METHOD method_25394 (Lnet/minecraft/class_4587;IIF)V

--- a/mappings/net/minecraft/client/gui/screen/NoticeScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/NoticeScreen.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_403 net/minecraft/client/gui/screen/NoticeScreen
 	FIELD field_2345 actionHandler Ljava/lang/Runnable;
 	FIELD field_2346 notice Lnet/minecraft/class_2561;
+	FIELD field_2347 disableButtonDelay I
 	FIELD field_2348 noticeLines Ljava/util/List;
 	FIELD field_2349 buttonString Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/Runnable;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)V
@@ -11,3 +12,5 @@ CLASS net/minecraft/class_403 net/minecraft/client/gui/screen/NoticeScreen
 		ARG 1 actionHandler
 		ARG 2 title
 		ARG 3 notice
+		ARG 4 buttonText
+	METHOD method_25393 ()V

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -46,6 +46,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 4 y
 	METHOD method_25418 renderTextHoverEffect (Lnet/minecraft/class_4587;Lnet/minecraft/class_2583;II)V
 		ARG 1 matrices
+		ARG 2 style
 	METHOD method_25419 onClose ()V
 	METHOD method_25420 renderBackground (Lnet/minecraft/class_4587;)V
 		COMMENT Renders the background of this screen.
@@ -74,6 +75,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25429 addChild (Lnet/minecraft/class_364;)Lnet/minecraft/class_364;
 		ARG 1 child
 	METHOD method_25430 handleTextClick (Lnet/minecraft/class_2583;)Z
+		ARG 1 style
 	METHOD method_25432 removed ()V
 	METHOD method_25433 renderBackground (Lnet/minecraft/class_4587;I)V
 		COMMENT Renders the background of this screen.
@@ -100,3 +102,5 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25441 hasControlDown ()Z
 	METHOD method_25442 hasShiftDown ()Z
 	METHOD method_25443 hasAltDown ()Z
+	METHOD method_29638 filesDragged (Ljava/util/List;)V
+		ARG 1 files

--- a/mappings/net/minecraft/client/gui/screen/SplashScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SplashScreen.mapping
@@ -7,6 +7,8 @@ CLASS net/minecraft/class_425 net/minecraft/client/gui/screen/SplashScreen
 	FIELD field_18219 reloading Z
 	FIELD field_18220 prepareCompleteTime J
 	FIELD field_2483 LOGO Lnet/minecraft/class_2960;
+	FIELD field_25041 BRAND_ARGB I
+	FIELD field_25042 BRAND_RBG I
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_4011;Ljava/util/function/Consumer;Z)V
 		ARG 1 client
 		ARG 2 monitor
@@ -15,4 +17,6 @@ CLASS net/minecraft/class_425 net/minecraft/client/gui/screen/SplashScreen
 	METHOD method_18103 renderProgressBar (Lnet/minecraft/class_4587;IIIIF)V
 	METHOD method_18819 init (Lnet/minecraft/class_310;)V
 		ARG 0 client
+	METHOD method_25394 (Lnet/minecraft/class_4587;IIF)V
 	CLASS class_4070 LogoTexture
+		METHOD method_18153 (Lnet/minecraft/class_3300;)Lnet/minecraft/class_1049$class_4006;

--- a/mappings/net/minecraft/client/gui/screen/world/CreateWorldScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/CreateWorldScreen.mapping
@@ -1,7 +1,15 @@
 CLASS net/minecraft/class_525 net/minecraft/client/gui/screen/world/CreateWorldScreen
+	FIELD field_24286 difficultyButton Lnet/minecraft/class_4185;
 	FIELD field_24287 gameRulesButton Lnet/minecraft/class_4185;
 	FIELD field_24288 gameRules Lnet/minecraft/class_1928;
+	FIELD field_24289 difficulty Lnet/minecraft/class_1267;
+	FIELD field_24290 safeDifficulty Lnet/minecraft/class_1267;
+		COMMENT ususally mirrors difficulty except in the case of {@link this.mode} being {@link CreateWorldScreen.Mode.HARDCORE}, in which case it stays at {@link Difficulty.HARD}. This is the difficulty that is used for button rendering and during {@link LevelInfo} creation.
 	FIELD field_24588 moreOptionsDialog Lnet/minecraft/class_5292;
+	FIELD field_25477 dataPackTempDir Ljava/nio/file/Path;
+	FIELD field_25478 dataPacksButton Lnet/minecraft/class_4185;
+	FIELD field_25479 dataPackSettings Lnet/minecraft/class_5359;
+	FIELD field_25480 logger Lorg/apache/logging/log4j/Logger;
 	FIELD field_3178 hardcore Z
 	FIELD field_3179 tweakedCheats Z
 	FIELD field_3182 enableCheatsButton Lnet/minecraft/class_4185;
@@ -20,6 +28,15 @@ CLASS net/minecraft/class_525 net/minecraft/client/gui/screen/world/CreateWorldS
 	FIELD field_3205 createLevelButton Lnet/minecraft/class_4185;
 	METHOD <init> (Lnet/minecraft/class_437;)V
 		ARG 1 parent
+	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_1940;Lnet/minecraft/class_5285;Ljava/nio/file/Path;Lnet/minecraft/class_5318$class_5319;)V
+		ARG 1 parent
+		ARG 2 levelInfo
+		ARG 3 options
+	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_5292;)V
+		ARG 1 parent
+		ARG 2 moreOptionsDialog
+	METHOD method_19416 (Ljava/lang/String;)V
+		ARG 1 newName
 	METHOD method_22365 tweakDefaultsTo (Lnet/minecraft/class_525$class_4539;)V
 	METHOD method_2710 setMoreOptionsOpen (Z)V
 		ARG 1 moreOptionsOpen

--- a/mappings/net/minecraft/client/gui/screen/world/MoreOptionsDialog.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/MoreOptionsDialog.mapping
@@ -9,14 +9,29 @@ CLASS net/minecraft/class_5292 net/minecraft/client/gui/screen/world/MoreOptions
 	FIELD field_24597 customizeTypeButton Lnet/minecraft/class_4185;
 	FIELD field_24598 generatorOptions Lnet/minecraft/class_5285;
 	FIELD field_24600 seedText Ljava/lang/String;
+	FIELD field_25046 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_25047 CUSTOM_TEXT Lnet/minecraft/class_2561;
+	FIELD field_25048 importSettingsButton Lnet/minecraft/class_4185;
+	FIELD field_25049 generatorType Ljava/util/Optional;
+	FIELD field_25483 registryManager Lnet/minecraft/class_5318$class_5319;
+	METHOD <init> (Lnet/minecraft/class_5318$class_5319;Lnet/minecraft/class_5285;)V
+		ARG 1 registryManager
+		ARG 2 options
 	METHOD method_28085 isDebugWorld ()Z
 	METHOD method_28086 setGeneratorOptions (Lnet/minecraft/class_5285;)V
+		ARG 1 options
 	METHOD method_28092 (Lnet/minecraft/class_525;Lnet/minecraft/class_310;Lnet/minecraft/class_327;)V
 		ARG 1 parent
 		ARG 2 client
 		ARG 3 textRenderer
 	METHOD method_28095 tryParseLong (Ljava/lang/String;)Ljava/util/OptionalLong;
+		ARG 0 seed
 	METHOD method_28096 getGeneratorOptions (Z)Lnet/minecraft/class_5285;
 		ARG 1 hardcore
+	METHOD method_28100 (Ljava/lang/String;)V
+		ARG 1 seed
 	METHOD method_28101 setVisible (Z)V
 		ARG 1 visible
+	METHOD method_29071 (Lnet/minecraft/class_525;Lnet/minecraft/class_310;Lnet/minecraft/class_4185;)V
+	METHOD method_29073 (Lnet/minecraft/class_5318$class_5319;Lnet/minecraft/class_5285;)V
+		ARG 2 options

--- a/mappings/net/minecraft/client/world/GeneratorType.mapping
+++ b/mappings/net/minecraft/client/world/GeneratorType.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_5317 net/minecraft/client/world/GeneratorType
 	FIELD field_25050 DEFAULT Lnet/minecraft/class_5317;
 	FIELD field_25051 AMPLIFIED Lnet/minecraft/class_5317;
 	FIELD field_25052 VALUES Ljava/util/List;
+	FIELD field_25053 SCREEN_PROVIDERS Ljava/util/Map;
 	FIELD field_25054 FLAT Lnet/minecraft/class_5317;
 	FIELD field_25055 LARGE_BIOMES Lnet/minecraft/class_5317;
 	FIELD field_25056 SINGLE_BIOME_SURFACE Lnet/minecraft/class_5317;

--- a/mappings/net/minecraft/entity/SpawnGroup.mapping
+++ b/mappings/net/minecraft/entity/SpawnGroup.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_1311 net/minecraft/entity/SpawnGroup
 	FIELD field_24461 despawnStartRange I
 	FIELD field_24462 immediateDespawnRange I
+	FIELD field_24655 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_6295 animal Z
 	FIELD field_6296 BY_NAME Ljava/util/Map;
 	FIELD field_6297 capacity I

--- a/mappings/net/minecraft/particle/ParticleTypes.mapping
+++ b/mappings/net/minecraft/particle/ParticleTypes.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2398 net/minecraft/particle/ParticleTypes
+	FIELD field_25125 CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_10303 register (Ljava/lang/String;Z)Lnet/minecraft/class_2400;
 		ARG 0 name
 		ARG 1 alwaysShow

--- a/mappings/net/minecraft/resource/FileResourcePackProvider.mapping
+++ b/mappings/net/minecraft/resource/FileResourcePackProvider.mapping
@@ -1,7 +1,9 @@
 CLASS net/minecraft/class_3279 net/minecraft/resource/FileResourcePackProvider
 	FIELD field_14217 POSSIBLE_PACK Ljava/io/FileFilter;
 	FIELD field_14218 packsFolder Ljava/io/File;
+	FIELD field_25345 source Lnet/minecraft/class_5352;
 	METHOD <init> (Ljava/io/File;Lnet/minecraft/class_5352;)V
 		ARG 1 packsFolder
+		ARG 2 source
 	METHOD method_14432 createResourcePack (Ljava/io/File;)Ljava/util/function/Supplier;
 		ARG 1 file

--- a/mappings/net/minecraft/resource/ReloadableResourceManagerImpl.mapping
+++ b/mappings/net/minecraft/resource/ReloadableResourceManagerImpl.mapping
@@ -5,15 +5,19 @@ CLASS net/minecraft/class_3304 net/minecraft/resource/ReloadableResourceManagerI
 	FIELD field_14295 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_17935 listeners Ljava/util/List;
 	FIELD field_17936 initialListeners Ljava/util/List;
+	FIELD field_25145 packs Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_3264;)V
 		ARG 1 type
 	METHOD method_14475 addPack (Lnet/minecraft/class_3262;)V
+		ARG 1 pack
+	METHOD method_14489 (Lnet/minecraft/class_2960;)Ljava/util/List;
 	METHOD method_14495 clear ()V
 	METHOD method_18240 beginReloadInner (Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Ljava/util/List;Ljava/util/concurrent/CompletableFuture;)Lnet/minecraft/class_4011;
 		ARG 1 prepareExecutor
 		ARG 2 applyExecutor
 		ARG 3 listeners
 		ARG 4 initialStage
+	METHOD method_29489 (Lnet/minecraft/class_2960;Ljava/util/function/Predicate;)Ljava/util/Collection;
 	CLASS class_4742 FailedResourceReloadMonitor
 		FIELD field_21810 exception Lnet/minecraft/class_3304$class_4743;
 		FIELD field_21811 future Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/resource/ResourcePackSource.mapping
+++ b/mappings/net/minecraft/resource/ResourcePackSource.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_5352 net/minecraft/resource/ResourcePackSource
+	FIELD field_25347 PACK_SOURCE_NONE Lnet/minecraft/class_5352;

--- a/mappings/net/minecraft/structure/StrongholdGenerator.mapping
+++ b/mappings/net/minecraft/structure/StrongholdGenerator.mapping
@@ -1,46 +1,261 @@
 CLASS net/minecraft/class_3421 net/minecraft/structure/StrongholdGenerator
 	FIELD field_15263 STONE_BRICK_RANDOMIZER Lnet/minecraft/class_3421$class_3432;
+	FIELD field_15264 totalWeight I
 	FIELD field_15265 ALL_PIECE_SETTINGS [Lnet/minecraft/class_3421$class_3427;
 	FIELD field_15266 activePieceType Ljava/lang/Class;
 	FIELD field_15267 possiblePieceSettings Ljava/util/List;
+	METHOD method_14847 createPiece (Ljava/lang/Class;Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3437;
+		ARG 0 pieceClass
+		ARG 2 random
+		ARG 3 x
+		ARG 4 y
+		ARG 5 z
+		ARG 6 direction
+		ARG 7 length
+	METHOD method_14851 pickPiece (Lnet/minecraft/class_3421$class_3434;Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3437;
+		ARG 0 start
+		ARG 2 random
+		ARG 3 x
+		ARG 4 y
+		ARG 5 z
+		ARG 6 direction
+		ARG 7 length
+	METHOD method_14852 checkRemainingPieces ()Z
+	METHOD method_14854 pieceGenerator (Lnet/minecraft/class_3421$class_3434;Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3443;
+		ARG 0 start
+		ARG 2 random
+		ARG 3 x
+		ARG 4 y
+		ARG 5 z
+		ARG 6 direction
+		ARG 7 length
 	METHOD method_14855 init ()V
 	CLASS class_3422 ChestCorridor
 		FIELD field_15268 chestGenerated Z
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14856 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3422;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3423 SmallCorridor
 		FIELD field_15269 length I
+		METHOD <init> (ILnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 boundingBox
+			ARG 3 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14857 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;)Lnet/minecraft/class_3341;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
 	CLASS class_3424 FiveWayCrossing
 		FIELD field_15270 upperRightExists Z
 		FIELD field_15271 lowerRightExists Z
 		FIELD field_15272 upperLeftExists Z
 		FIELD field_15273 lowerLeftExists Z
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14858 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3424;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3425 LeftTurn
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14859 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3425;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3426 Library
 		FIELD field_15274 tall Z
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14860 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3426;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3427 PieceSetting
 		FIELD field_15275 limit I
 		FIELD field_15276 pieceType Ljava/lang/Class;
 		FIELD field_15277 generatedCount I
+		FIELD field_15278 weight I
+		METHOD <init> (Ljava/lang/Class;II)V
+			ARG 1 pieceClass
+			ARG 2 weight
+			ARG 3 limit
 		METHOD method_14861 canGenerate ()Z
 		METHOD method_14862 canGenerate (I)Z
 			ARG 1 depth
 	CLASS class_3428 PortalRoom
 		FIELD field_15279 spawnerPlaced Z
+		METHOD <init> (ILnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 boundingBox
+			ARG 3 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14863 create (Ljava/util/List;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3428;
+			ARG 1 x
+			ARG 2 y
+			ARG 3 z
+			ARG 4 direction
+			ARG 5 length
 	CLASS class_3429 PrisonHall
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14864 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3429;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3430 RightTurn
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_16652 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3430;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3431 SquareRoom
 		FIELD field_15280 roomType I
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14865 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3431;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3432 StoneBrickRandomizer
 	CLASS class_3433 SpiralStaircase
 		FIELD field_15281 isStructureStart Z
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD <init> (Lnet/minecraft/class_3773;ILjava/util/Random;II)V
+			ARG 1 type
+			ARG 2 length
+			ARG 3 random
+			ARG 4 x
+			ARG 5 y
+		METHOD method_14866 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3433;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3434 Start
+		FIELD field_15282 pieces Ljava/util/List;
+		FIELD field_15283 portalRoom Lnet/minecraft/class_3421$class_3428;
+		FIELD field_15284 lastPiece Lnet/minecraft/class_3421$class_3427;
+		METHOD <init> (Ljava/util/Random;II)V
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
 	CLASS class_3435 Corridor
 		FIELD field_15285 rightExitExists Z
 		FIELD field_15286 leftExitExists Z
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14867 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3435;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3436 Stairs
+		METHOD <init> (ILjava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_2350;)V
+			ARG 1 length
+			ARG 2 random
+			ARG 3 boundingBox
+			ARG 4 direction
+		METHOD <init> (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)V
+			ARG 2 tag
+		METHOD method_14868 create (Ljava/util/List;Ljava/util/Random;IIILnet/minecraft/class_2350;I)Lnet/minecraft/class_3421$class_3436;
+			ARG 1 random
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+			ARG 5 direction
+			ARG 6 length
 	CLASS class_3437 Piece
 		FIELD field_15287 entryDoor Lnet/minecraft/class_3421$class_3437$class_3438;
 		METHOD method_14869 getRandomEntrance (Ljava/util/Random;)Lnet/minecraft/class_3421$class_3437$class_3438;
 			ARG 1 random
+		METHOD method_14870 fillNWOpening (Lnet/minecraft/class_3421$class_3434;Ljava/util/List;Ljava/util/Random;II)Lnet/minecraft/class_3443;
+			ARG 1 start
+			ARG 3 random
+			ARG 4 y
+			ARG 5 z
+		METHOD method_14871 isInBounds (Lnet/minecraft/class_3341;)Z
+			ARG 0 boundingBox
 		METHOD method_14872 generateEntrance (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_3421$class_3437$class_3438;III)V
 			ARG 1 world
 			ARG 2 random
@@ -49,5 +264,15 @@ CLASS net/minecraft/class_3421 net/minecraft/structure/StrongholdGenerator
 			ARG 5 x
 			ARG 6 y
 			ARG 7 z
+		METHOD method_14873 fillSWOpening (Lnet/minecraft/class_3421$class_3434;Ljava/util/List;Ljava/util/Random;II)Lnet/minecraft/class_3443;
+			ARG 1 start
+			ARG 3 random
+			ARG 4 y
+			ARG 5 z
+		METHOD method_14874 fillForwardOpening (Lnet/minecraft/class_3421$class_3434;Ljava/util/List;Ljava/util/Random;II)Lnet/minecraft/class_3443;
+			ARG 1 start
+			ARG 3 random
+			ARG 4 x
+			ARG 5 y
 		CLASS class_3438 EntranceType
 	CLASS class_3466 Turn

--- a/mappings/net/minecraft/structure/Structure.mapping
+++ b/mappings/net/minecraft/structure/Structure.mapping
@@ -88,6 +88,7 @@ CLASS net/minecraft/class_3499 net/minecraft/structure/Structure
 		ARG 3 startX
 		ARG 4 startY
 		ARG 5 startZ
+	METHOD method_27267 calculateBoundingBox (Lnet/minecraft/class_2338;Lnet/minecraft/class_2470;Lnet/minecraft/class_2338;Lnet/minecraft/class_2415;)Lnet/minecraft/class_3341;
 	CLASS class_3500 Palette
 		FIELD field_15590 AIR Lnet/minecraft/class_2680;
 		FIELD field_15591 ids Lnet/minecraft/class_2361;

--- a/mappings/net/minecraft/structure/StructurePiece.mapping
+++ b/mappings/net/minecraft/structure/StructurePiece.mapping
@@ -28,6 +28,9 @@ CLASS net/minecraft/class_3443 net/minecraft/structure/StructurePiece
 		ARG 4 y
 		ARG 5 z
 	METHOD method_14918 placeJigsaw (Lnet/minecraft/class_3443;Ljava/util/List;Ljava/util/Random;)V
+		ARG 1 start
+		ARG 2 pieces
+		ARG 3 random
 	METHOD method_14919 (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;IIIIIILnet/minecraft/class_2680;Z)V
 		ARG 1 world
 		ARG 2 bounds
@@ -68,6 +71,7 @@ CLASS net/minecraft/class_3443 net/minecraft/structure/StructurePiece
 		ARG 7 facing
 		ARG 8 lootTableId
 	METHOD method_14931 generate (Lnet/minecraft/class_5281;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_1923;Lnet/minecraft/class_2338;)Z
+		ARG 1 world
 		ARG 2 structureAccessor
 		ARG 3 chunkGenerator
 		ARG 4 random

--- a/mappings/net/minecraft/structure/StructureStart.mapping
+++ b/mappings/net/minecraft/structure/StructureStart.mapping
@@ -26,6 +26,13 @@ CLASS net/minecraft/class_3449 net/minecraft/structure/StructureStart
 		ARG 1 chunkX
 		ARG 2 chunkZ
 	METHOD method_14974 generateStructure (Lnet/minecraft/class_5281;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_1923;)V
+		ARG 1 world
+		ARG 2 structureAccessor
+		ARG 3 generator
+		ARG 4 random
+		ARG 5 boundingBox
+		ARG 6 pos
+	METHOD method_14978 randomUpwardTranslation (ILjava/util/Random;I)V
 	METHOD method_14979 isInExistingChunk ()Z
 	METHOD method_16655 init (Lnet/minecraft/class_2794;Lnet/minecraft/class_3485;IILnet/minecraft/class_1959;Lnet/minecraft/class_3037;)V
 		ARG 1 chunkGenerator
@@ -33,6 +40,7 @@ CLASS net/minecraft/class_3449 net/minecraft/structure/StructureStart
 		ARG 3 x
 		ARG 4 z
 		ARG 5 biome
+		ARG 6 config
 	METHOD method_16656 getFeature ()Lnet/minecraft/class_3195;
 	METHOD method_16657 hasChildren ()Z
 	METHOD method_23676 getReferences ()I

--- a/mappings/net/minecraft/tag/SetTag.mapping
+++ b/mappings/net/minecraft/tag/SetTag.mapping
@@ -1,5 +1,4 @@
 CLASS net/minecraft/class_5394 net/minecraft/tag/SetTag
-	FIELD field_25592 EMPTY Lnet/minecraft/class_5394;
 	FIELD field_25593 values Lcom/google/common/collect/ImmutableList;
 	METHOD <init> (Ljava/util/Set;Ljava/lang/Class;)V
 		ARG 1 set

--- a/mappings/net/minecraft/util/StringIdentifiable.mapping
+++ b/mappings/net/minecraft/util/StringIdentifiable.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_3542 net/minecraft/util/StringIdentifiable
 	METHOD method_15434 asString ()Ljava/lang/String;
+	METHOD method_28140 createCodec (Ljava/util/function/Supplier;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;
+	METHOD method_28142 toKeyable ([Lnet/minecraft/class_3542;)Lcom/mojang/serialization/Keyable;

--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -25,12 +25,14 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 	METHOD method_27173 getRandom ([Ljava/lang/Object;Ljava/util/Random;)Ljava/lang/Object;
 		ARG 0 array
 		ARG 1 random
+	METHOD method_27760 backupAndReplace (Ljava/io/File;Ljava/io/File;Ljava/io/File;)V
 	METHOD method_27761 moveCursor (Ljava/lang/String;II)I
 		COMMENT Moves the {@code cursor} in the {@code string} by a {@code delta} amount.
 		COMMENT Skips surrogate characters.
 		ARG 0 string
 		ARG 1 cursor
 		ARG 2 delta
+	METHOD method_29188 addPrefix (Ljava/lang/String;Ljava/util/function/Consumer;)Ljava/util/function/Consumer;
 	METHOD method_29190 toIntArray (Ljava/util/stream/IntStream;I)Lcom/mojang/serialization/DataResult;
 		ARG 0 intStream
 		ARG 1 length

--- a/mappings/net/minecraft/util/collection/WeightedList.mapping
+++ b/mappings/net/minecraft/util/collection/WeightedList.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_4131 net/minecraft/util/collection/WeightedList
 		ARG 1 random
 	METHOD method_23337 pickRandom (Ljava/util/Random;)Ljava/lang/Object;
 		ARG 1 random
+	METHOD method_28338 createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+	METHOD method_28339 isEmpty ()Z
 	CLASS class_4132 Entry
 		FIELD field_18400 item Ljava/lang/Object;
 		FIELD field_18401 weight I

--- a/mappings/net/minecraft/util/dynamic/DynamicSerializableUuid.mapping
+++ b/mappings/net/minecraft/util/dynamic/DynamicSerializableUuid.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_4844 net/minecraft/util/dynamic/DynamicSerializableUuid
+	FIELD field_25122 CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_26274 toIntArray (JJ)[I
 		ARG 0 uuidMost
 		ARG 2 uuidLeast

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -17,6 +17,7 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 	FIELD field_10981 BIT_SHIFT_X I
 	FIELD field_10983 BIT_SHIFT_Z I
 	FIELD field_18789 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_25064 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_2374;)V
 		ARG 1 pos
 	METHOD <init> (Lnet/minecraft/class_2382;)V
@@ -141,6 +142,8 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		ARG 1 maxX
 		ARG 2 maxY
 		ARG 3 maxZ
+	METHOD method_27156 iterateRandomly (Ljava/util/Random;IIIIIII)Ljava/lang/Iterable;
+	METHOD method_29715 stream (Lnet/minecraft/class_238;)Ljava/util/stream/Stream;
 	CLASS 2
 		FIELD field_23094 maxDistance I
 		FIELD field_23095 xRange I
@@ -203,3 +206,4 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 			COMMENT pos by the given direction.
 			ARG 1 pos
 			ARG 2 direction
+		METHOD method_27158 clamp (Lnet/minecraft/class_2350$class_2351;II)Lnet/minecraft/class_2338$class_2339;

--- a/mappings/net/minecraft/util/math/ChunkPos.mapping
+++ b/mappings/net/minecraft/util/math/ChunkPos.mapping
@@ -21,6 +21,7 @@ CLASS net/minecraft/class_1923 net/minecraft/util/math/ChunkPos
 	METHOD method_19281 stream (Lnet/minecraft/class_1923;Lnet/minecraft/class_1923;)Ljava/util/stream/Stream;
 		ARG 0 pos1
 		ARG 1 pos2
+	METHOD method_24022 getChebyshevDistance (Lnet/minecraft/class_1923;)I
 	METHOD method_8323 getCenterBlockPos ()Lnet/minecraft/class_2338;
 	METHOD method_8324 toLong ()J
 	METHOD method_8325 getPackedX (J)I

--- a/mappings/net/minecraft/world/BlockCollisionSpliterator.mapping
+++ b/mappings/net/minecraft/world/BlockCollisionSpliterator.mapping
@@ -7,10 +7,16 @@ CLASS net/minecraft/class_5329 net/minecraft/world/BlockCollisionSpliterator
 	FIELD field_25173 boxShape Lnet/minecraft/class_265;
 	FIELD field_25174 world Lnet/minecraft/class_1941;
 	FIELD field_25175 checkEntity Z
+	FIELD field_25669 blockPredicate Ljava/util/function/BiPredicate;
 	METHOD <init> (Lnet/minecraft/class_1941;Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)V
 		ARG 1 world
 		ARG 2 entity
 		ARG 3 box
+	METHOD <init> (Lnet/minecraft/class_1941;Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)V
+		ARG 1 world
+		ARG 2 entity
+		ARG 3 box
+		ARG 4 blockPredicate
 	METHOD method_29283 getChunk (II)Lnet/minecraft/class_1922;
 		ARG 1 x
 		ARG 2 z
@@ -18,4 +24,14 @@ CLASS net/minecraft/class_5329 net/minecraft/world/BlockCollisionSpliterator
 		ARG 0 border
 		ARG 1 box
 	METHOD method_29285 offerBlockShape (Ljava/util/function/Consumer;)Z
+		ARG 1 voxelShapeConsumer
 	METHOD method_29286 offerEntityShape (Ljava/util/function/Consumer;)Z
+		ARG 1 voxelShapeConsumer
+	METHOD method_30130 collidesSlightlyLarger (Lnet/minecraft/class_265;Lnet/minecraft/class_238;)Z
+		ARG 0 shape
+		ARG 1 box
+	METHOD method_30131 collidesSlightlySmaller (Lnet/minecraft/class_265;Lnet/minecraft/class_238;)Z
+		ARG 0 shape
+		ARG 1 box
+	METHOD tryAdvance (Ljava/util/function/Consumer;)Z
+		ARG 1 voxelShapeConsumer

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_1922 net/minecraft/world/BlockView
 	METHOD method_17742 rayTrace (Lnet/minecraft/class_3959;)Lnet/minecraft/class_3965;
 		ARG 1 context
 	METHOD method_17744 rayTrace (Lnet/minecraft/class_3959;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
+		ARG 0 rayTraceContext
 		ARG 1 context
 		ARG 2 blockRayTracer
 	METHOD method_17745 rayTraceBlock (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3965;
@@ -11,6 +12,8 @@ CLASS net/minecraft/class_1922 net/minecraft/world/BlockView
 		ARG 3 pos
 		ARG 4 shape
 		ARG 5 state
+	METHOD method_29546 getStatesInBox (Lnet/minecraft/class_238;)Ljava/util/stream/Stream;
+		ARG 1 box
 	METHOD method_8315 getMaxLightLevel ()I
 	METHOD method_8316 getFluidState (Lnet/minecraft/class_2338;)Lnet/minecraft/class_3610;
 		ARG 1 pos

--- a/mappings/net/minecraft/world/ChunkSerializer.mapping
+++ b/mappings/net/minecraft/world/ChunkSerializer.mapping
@@ -19,6 +19,9 @@ CLASS net/minecraft/class_2852 net/minecraft/world/ChunkSerializer
 	METHOD method_12391 (Lnet/minecraft/class_3611;)Z
 		ARG 0 fluid
 	METHOD method_12392 readStructureStarts (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;J)Ljava/util/Map;
+		ARG 0 structureManager
+		ARG 1 tag
+		ARG 2 seed
 	METHOD method_12393 toNbt ([Lit/unimi/dsi/fastutil/shorts/ShortList;)Lnet/minecraft/class_2499;
 		ARG 0 lists
 	METHOD method_12395 deserialize (Lnet/minecraft/class_3218;Lnet/minecraft/class_3485;Lnet/minecraft/class_4153;Lnet/minecraft/class_1923;Lnet/minecraft/class_2487;)Lnet/minecraft/class_2839;

--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -4,21 +4,29 @@ CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
 	METHOD method_18026 doesNotCollide (Lnet/minecraft/class_238;)Z
 		ARG 1 box
 	METHOD method_20743 getEntityCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
+		ARG 1 arg
 	METHOD method_20812 getBlockCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Ljava/util/stream/Stream;
 		ARG 1 entity
 		ARG 2 box
 	METHOD method_22338 getExistingChunk (II)Lnet/minecraft/class_1922;
 		ARG 1 chunkX
 		ARG 2 chunkZ
+	METHOD method_30030 getBlockCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Ljava/util/stream/Stream;
+		ARG 1 entity
+		ARG 2 box
 	METHOD method_8587 doesNotCollide (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Z
 		ARG 1 entity
 		ARG 2 box
 	METHOD method_8590 doesNotCollide (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Z
+		ARG 1 entity
+		ARG 2 box
 	METHOD method_8600 getCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
+		ARG 1 entity
+		ARG 2 box
 	METHOD method_8606 intersectsEntities (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
 	METHOD method_8611 intersectsEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_265;)Z
-		ARG 1 except
+		ARG 1 entity
 		ARG 2 shape
 	METHOD method_8621 getWorldBorder ()Lnet/minecraft/class_2784;
 	METHOD method_8628 canPlace (Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_3726;)Z

--- a/mappings/net/minecraft/world/FeatureUpdater.mapping
+++ b/mappings/net/minecraft/world/FeatureUpdater.mapping
@@ -4,8 +4,14 @@ CLASS net/minecraft/class_3360 net/minecraft/world/FeatureUpdater
 	FIELD field_14434 needsUpdate Z
 	FIELD field_14435 OLD_TO_NEW Ljava/util/Map;
 	FIELD field_14436 ANCIENT_TO_OLD Ljava/util/Map;
+	FIELD field_17658 oldNames Ljava/util/List;
+	FIELD field_17659 newNames Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_26;Ljava/util/List;Ljava/util/List;)V
+		ARG 2 oldNames
+		ARG 3 newNames
 	METHOD method_14734 init (Lnet/minecraft/class_26;)V
 	METHOD method_14735 getUpdatedReferences (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
+		ARG 1 tag
 	METHOD method_14737 needsUpdate (II)Z
 		ARG 1 chunkX
 		ARG 2 chunkZ
@@ -14,5 +20,8 @@ CLASS net/minecraft/class_3360 net/minecraft/world/FeatureUpdater
 		ARG 2 chunkZ
 		ARG 3 id
 	METHOD method_14741 getUpdatedStarts (Lnet/minecraft/class_2487;Lnet/minecraft/class_1923;)Lnet/minecraft/class_2487;
+		ARG 1 tag
+		ARG 2 pos
 	METHOD method_14744 markResolved (J)V
 	METHOD method_14745 create (Lnet/minecraft/class_5321;Lnet/minecraft/class_26;)Lnet/minecraft/class_3360;
+		ARG 0 worldTag

--- a/mappings/net/minecraft/world/Heightmap.mapping
+++ b/mappings/net/minecraft/world/Heightmap.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_2902 net/minecraft/world/Heightmap
 	FIELD field_16744 ALWAYS_TRUE Ljava/util/function/Predicate;
 	FIELD field_16745 SUFFOCATES Ljava/util/function/Predicate;
 	METHOD <init> (Lnet/minecraft/class_2791;Lnet/minecraft/class_2902$class_2903;)V
+		ARG 1 chunk
 		ARG 2 type
 	METHOD method_12595 toIndex (II)I
 		ARG 0 x
@@ -27,17 +28,21 @@ CLASS net/minecraft/class_2902 net/minecraft/world/Heightmap
 		ARG 1 x
 		ARG 2 z
 	METHOD method_16684 populateHeightmaps (Lnet/minecraft/class_2791;Ljava/util/Set;)V
+		ARG 0 chunk
 		ARG 1 types
 	CLASS class_2903 Type
 		FIELD field_13198 purpose Lnet/minecraft/class_2902$class_2904;
 		FIELD field_13204 name Ljava/lang/String;
 		FIELD field_13205 BY_NAME Ljava/util/Map;
 		FIELD field_16568 blockPredicate Ljava/util/function/Predicate;
+		FIELD field_24772 CODEC Lcom/mojang/serialization/Codec;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/class_2902$class_2904;Ljava/util/function/Predicate;)V
 			ARG 3 name
 			ARG 4 purpose
 			ARG 5 blockPredicate
 		METHOD method_12605 getName ()Ljava/lang/String;
+		METHOD method_12608 (Ljava/util/HashMap;)V
+			ARG 0 hashMap
 		METHOD method_12609 byName (Ljava/lang/String;)Lnet/minecraft/class_2902$class_2903;
 			ARG 0 name
 		METHOD method_16137 shouldSendToClient ()Z

--- a/mappings/net/minecraft/world/MobSpawnerLogic.mapping
+++ b/mappings/net/minecraft/world/MobSpawnerLogic.mapping
@@ -9,7 +9,9 @@ CLASS net/minecraft/class_1917 net/minecraft/world/MobSpawnerLogic
 	FIELD field_9156 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_9157 spawnRange I
 	FIELD field_9158 requiredPlayerRange I
+	FIELD field_9159 lastRotation D
 	FIELD field_9160 maxNearbyEntities I
+	FIELD field_9161 rotation D
 	METHOD method_18086 spawnEntity (Lnet/minecraft/class_1297;)V
 	METHOD method_8271 getWorld ()Lnet/minecraft/class_1937;
 	METHOD method_8272 toTag (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
@@ -18,9 +20,12 @@ CLASS net/minecraft/class_1917 net/minecraft/world/MobSpawnerLogic
 		ARG 1 status
 	METHOD method_8274 setEntityId (Lnet/minecraft/class_1299;)V
 		ARG 1 type
+	METHOD method_8275 handleStatus (I)Z
 	METHOD method_8276 getPos ()Lnet/minecraft/class_2338;
 	METHOD method_8277 setSpawnEntry (Lnet/minecraft/class_1952;)V
 		ARG 1 spawnEntry
+	METHOD method_8278 getRotation ()D
+	METHOD method_8279 getLastRotation ()D
 	METHOD method_8280 fromTag (Lnet/minecraft/class_2487;)V
 		ARG 1 tag
 	METHOD method_8281 getEntityId ()Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/world/SaveProperties.mapping
+++ b/mappings/net/minecraft/world/SaveProperties.mapping
@@ -2,8 +2,11 @@ CLASS net/minecraft/class_5219 net/minecraft/world/SaveProperties
 	METHOD method_146 getGameRules ()Lnet/minecraft/class_1928;
 	METHOD method_150 getLevelName ()Ljava/lang/String;
 	METHOD method_151 populateCrashReport (Lnet/minecraft/class_129;)V
+		ARG 1 section
 	METHOD method_152 isHardcore ()Z
 	METHOD method_163 cloneWorldTag (Lnet/minecraft/class_5318;Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
+		ARG 1 registryTracker
+		ARG 2 tag
 	METHOD method_168 getVersion ()I
 	METHOD method_186 setDifficultyLocked (Z)V
 		ARG 1 locked
@@ -29,3 +32,10 @@ CLASS net/minecraft/class_5219 net/minecraft/world/SaveProperties
 		ARG 1 id
 	METHOD method_27859 getMainWorldProperties ()Lnet/minecraft/class_5268;
 	METHOD method_28057 getGeneratorOptions ()Lnet/minecraft/class_5285;
+	METHOD method_29036 getDragonFight ()Lnet/minecraft/class_2487;
+	METHOD method_29037 setDragonFight (Lnet/minecraft/class_2487;)V
+		ARG 1 tag
+	METHOD method_29588 getLifecycle ()Lcom/mojang/serialization/Lifecycle;
+	METHOD method_29589 getDataPackSettings ()Lnet/minecraft/class_5359;
+	METHOD method_29590 updateLevelInfo (Lnet/minecraft/class_5359;)V
+		ARG 1 settings

--- a/mappings/net/minecraft/world/SpawnHelper.mapping
+++ b/mappings/net/minecraft/world/SpawnHelper.mapping
@@ -43,6 +43,8 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 	METHOD method_27822 getBiomeDirectly (Lnet/minecraft/class_2338;Lnet/minecraft/class_2791;)Lnet/minecraft/class_1959;
 		ARG 0 pos
 		ARG 1 chunk
+	METHOD method_29950 getSpawnEntries (Lnet/minecraft/class_3218;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Lnet/minecraft/class_1311;Lnet/minecraft/class_2338;Lnet/minecraft/class_1959;)Ljava/util/List;
+		ARG 0 world
 	METHOD method_8657 getSpawnPos (Lnet/minecraft/class_1937;Lnet/minecraft/class_2818;)Lnet/minecraft/class_2338;
 		ARG 0 world
 		ARG 1 chunk
@@ -52,6 +54,7 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		ARG 2 x
 		ARG 3 z
 	METHOD method_8659 containsSpawnEntry (Lnet/minecraft/class_3218;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Lnet/minecraft/class_1311;Lnet/minecraft/class_1959$class_1964;Lnet/minecraft/class_2338;)Z
+		ARG 0 world
 	METHOD method_8660 canSpawn (Lnet/minecraft/class_1317$class_1319;Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;Lnet/minecraft/class_1299;)Z
 		ARG 0 location
 		ARG 1 world
@@ -62,6 +65,7 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		ARG 1 biome
 		ARG 2 chunkX
 		ARG 3 chunkZ
+		ARG 4 random
 	METHOD method_8662 isClearForSpawn (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3610;Lnet/minecraft/class_1299;)Z
 		ARG 0 blockView
 		ARG 1 pos
@@ -74,6 +78,7 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		ARG 3 checker
 		ARG 4 runner
 	METHOD method_8664 pickRandomSpawnEntry (Lnet/minecraft/class_3218;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Lnet/minecraft/class_1311;Ljava/util/Random;Lnet/minecraft/class_2338;)Lnet/minecraft/class_1959$class_1964;
+		ARG 0 world
 	CLASS class_5259 Runner
 		METHOD run (Lnet/minecraft/class_1308;Lnet/minecraft/class_2791;)V
 			ARG 1 entity

--- a/mappings/net/minecraft/world/WanderingTraderManager.mapping
+++ b/mappings/net/minecraft/world/WanderingTraderManager.mapping
@@ -3,8 +3,18 @@ CLASS net/minecraft/class_3990 net/minecraft/world/WanderingTraderManager
 	FIELD field_17728 spawnTimer I
 	FIELD field_17729 spawnDelay I
 	FIELD field_17730 spawnChance I
+	FIELD field_24387 properties Lnet/minecraft/class_5268;
+	METHOD <init> (Lnet/minecraft/class_5268;)V
+		ARG 1 properties
 	METHOD method_18016 spawnLlama (Lnet/minecraft/class_3989;I)V
 		ARG 1 wanderingTrader
 		ARG 2 range
 	METHOD method_18017 getNearbySpawnPos (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;I)Lnet/minecraft/class_2338;
+		ARG 1 view
+		ARG 2 pos
+		ARG 3 range
+	METHOD method_18018 trySpawn (Lnet/minecraft/class_3218;)Z
+		ARG 1 world
 	METHOD method_23279 doesNotSuffocateAt (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
+		ARG 1 view
+		ARG 2 pos

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -29,7 +29,14 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	FIELD field_9253 rainGradientPrev F
 	FIELD field_9256 lcgBlockSeed I
 	METHOD <init> (Lnet/minecraft/class_5269;Lnet/minecraft/class_5321;Lnet/minecraft/class_5321;Lnet/minecraft/class_2874;Ljava/util/function/Supplier;ZZJ)V
+		ARG 1 properties
+		ARG 2 registryKey
+		ARG 3 dimensionRegistryKey
+		ARG 4 dimension
 		ARG 5 profiler
+		ARG 6 isClient
+		ARG 7 debugWorld
+		ARG 8 seed
 	METHOD method_16107 getProfiler ()Lnet/minecraft/class_3695;
 	METHOD method_16109 scheduleBlockRerenderIfNeeded (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2680;)V
 		ARG 1 pos
@@ -67,6 +74,14 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 pos
 		ARG 2 entity
 		ARG 3 direction
+	METHOD method_24794 isInBuildLimit (Lnet/minecraft/class_2338;)Z
+		ARG 0 pos
+	METHOD method_25952 isInvalidVertically (I)Z
+		ARG 0 y
+	METHOD method_25953 isValid (Lnet/minecraft/class_2338;)Z
+		ARG 0 pos
+	METHOD method_26096 getRelativeCeilingHeight (Lnet/minecraft/class_2338;D)D
+		ARG 1 pos
 	METHOD method_26097 getCollisionHeightAt (Lnet/minecraft/class_2338;Ljava/util/function/Predicate;)D
 		ARG 1 pos
 	METHOD method_26372 getCollisionHeightAt (Lnet/minecraft/class_2338;)D
@@ -124,6 +139,13 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8454 createExplosion (Lnet/minecraft/class_1297;Lnet/minecraft/class_1282;Lnet/minecraft/class_5362;DDDFZLnet/minecraft/class_1927$class_4179;)Lnet/minecraft/class_1927;
 		ARG 1 entity
 		ARG 2 damageSource
+		ARG 3 behavior
+		ARG 4 x
+		ARG 6 y
+		ARG 8 z
+		ARG 10 power
+		ARG 11 createFire
+		ARG 12 destructionType
 	METHOD method_8455 updateComparators (Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;)V
 		ARG 1 pos
 		ARG 2 block
@@ -176,6 +198,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 8 category
 		ARG 9 volume
 		ARG 10 pitch
+		ARG 11 delay
 	METHOD method_8488 getReceivedStrongRedstonePower (Lnet/minecraft/class_2338;)I
 		ARG 1 pos
 	METHOD method_8492 updateNeighbor (Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;Lnet/minecraft/class_2338;)V
@@ -241,6 +264,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+		ARG 4 bound
 	METHOD method_8537 createExplosion (Lnet/minecraft/class_1297;DDDFZLnet/minecraft/class_1927$class_4179;)Lnet/minecraft/class_1927;
 		ARG 1 entity
 		ARG 2 x
@@ -263,5 +287,5 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 9 velocityY
 		ARG 11 velocityZ
 		ARG 13 tag
-	METHOD method_8558 isValid (Lnet/minecraft/class_2338;)Z
+	METHOD method_8558 isValidHorizontally (Lnet/minecraft/class_2338;)Z
 		ARG 0 pos

--- a/mappings/net/minecraft/world/WorldSaveHandler.mapping
+++ b/mappings/net/minecraft/world/WorldSaveHandler.mapping
@@ -2,6 +2,11 @@ CLASS net/minecraft/class_29 net/minecraft/world/WorldSaveHandler
 	FIELD field_144 playerDataDir Ljava/io/File;
 	FIELD field_148 dataFixer Lcom/mojang/datafixers/DataFixer;
 	FIELD field_149 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD <init> (Lnet/minecraft/class_32$class_5143;Lcom/mojang/datafixers/DataFixer;)V
+		ARG 1 session
+		ARG 2 dataFixer
 	METHOD method_261 loadPlayerData (Lnet/minecraft/class_1657;)Lnet/minecraft/class_2487;
+		ARG 1 player
 	METHOD method_262 savePlayerData (Lnet/minecraft/class_1657;)V
+		ARG 1 player
 	METHOD method_263 getSavedPlayerIds ()[Ljava/lang/String;

--- a/mappings/net/minecraft/world/WorldView.mapping
+++ b/mappings/net/minecraft/world/WorldView.mapping
@@ -43,6 +43,8 @@ CLASS net/minecraft/class_4538 net/minecraft/world/WorldView
 		ARG 3 biomeZ
 	METHOD method_23753 getBiome (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1959;
 		ARG 1 pos
+	METHOD method_29556 getStatesInBoxIfLoaded (Lnet/minecraft/class_238;)Ljava/util/stream/Stream;
+		ARG 1 box
 	METHOD method_8392 getChunk (II)Lnet/minecraft/class_2791;
 		ARG 1 chunkX
 		ARG 2 chunkZ

--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 	FIELD field_22039 effects Lnet/minecraft/class_4763;
 	FIELD field_22040 noisePoints Ljava/util/List;
 	FIELD field_24406 spawnDensities Ljava/util/Map;
+	FIELD field_24677 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_9323 BIOMES Ljava/util/Set;
 	FIELD field_9324 FOLIAGE_NOISE Lnet/minecraft/class_3543;
 	FIELD field_9325 spawns Ljava/util/Map;
@@ -25,6 +26,22 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 	FIELD field_9343 depth F
 	METHOD <init> (Lnet/minecraft/class_1959$class_1960;)V
 		ARG 1 settings
+	METHOD <init> (Lnet/minecraft/class_1959$class_1963;Lnet/minecraft/class_1959$class_1961;FFFFLnet/minecraft/class_4763;ILnet/minecraft/class_3504;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/Optional;)V
+		ARG 1 precipitation
+		ARG 2 category
+		ARG 3 depth
+		ARG 4 scale
+		ARG 5 temperature
+		ARG 6 downfall
+		ARG 7 effects
+		ARG 8 skyColor
+		ARG 9 surfaceBuilder
+		ARG 10 carvers
+		ARG 11 features
+		ARG 12 structureFeatures
+		ARG 13 spawns
+		ARG 14 nousePoints
+		ARG 15 parentBiome
 	METHOD method_21740 getTemperature (Lnet/minecraft/class_2338;)F
 		ARG 1 blockPos
 	METHOD method_24218 calculateSkyColor ()I
@@ -35,12 +52,15 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 	METHOD method_24936 getMoodSound ()Ljava/util/Optional;
 	METHOD method_24937 getAdditionsSound ()Ljava/util/Optional;
 	METHOD method_27342 streamNoises ()Ljava/util/stream/Stream;
+	METHOD method_27343 getMusic ()Ljava/util/Optional;
 	METHOD method_27835 getSpawnDensity (Lnet/minecraft/class_1299;)Lnet/minecraft/class_1959$class_5265;
 		ARG 1 type
 	METHOD method_27836 addSpawnDensity (Lnet/minecraft/class_1299;DD)V
 		ARG 1 type
 		ARG 2 maxMass
 		ARG 4 mass
+	METHOD method_28405 getConfiguredStructureFeature (Lnet/minecraft/class_5312;)Lnet/minecraft/class_5312;
+		ARG 1 configuredStructureFeature
 	METHOD method_28413 getStructureFeatures ()Ljava/lang/Iterable;
 	METHOD method_8684 hasStructureFeature (Lnet/minecraft/class_3195;)Z
 		ARG 1 structureFeature
@@ -71,6 +91,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 		ARG 1 step
 		ARG 2 structureAccessor
 		ARG 3 chunkGenerator
+		ARG 4 serverWorldAccess
 		ARG 5 populationSeed
 		ARG 7 chunkRandom
 		ARG 8 pos
@@ -156,10 +177,13 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 		METHOD method_8747 temperature (F)Lnet/minecraft/class_1959$class_1960;
 			ARG 1 temperature
 	CLASS class_1961 Category
+		FIELD field_24678 CODEC Lcom/mojang/serialization/Codec;
 		FIELD field_9359 NAME_MAP Ljava/util/Map;
 		FIELD field_9372 name Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
+		METHOD method_28424 byName (Ljava/lang/String;)Lnet/minecraft/class_1959$class_1961;
+			ARG 0 name
 		METHOD method_8749 getName ()Ljava/lang/String;
 	CLASS class_1962 TemperatureGroup
 		FIELD field_9374 NAME_MAP Ljava/util/Map;
@@ -168,10 +192,13 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 			ARG 3 name
 		METHOD method_8750 getName ()Ljava/lang/String;
 	CLASS class_1963 Precipitation
+		FIELD field_24680 CODEC Lcom/mojang/serialization/Codec;
 		FIELD field_9381 NAME_MAP Ljava/util/Map;
 		FIELD field_9385 name Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
+		METHOD method_28431 byName (Ljava/lang/String;)Lnet/minecraft/class_1959$class_1963;
+			ARG 0 name
 		METHOD method_8752 getName ()Ljava/lang/String;
 	CLASS class_1964 SpawnEntry
 		FIELD field_24681 CODEC Lcom/mojang/serialization/Codec;
@@ -206,6 +233,8 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 			ARG 3 altitude
 			ARG 4 weirdness
 			ARG 5 weight
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 1 object
 		METHOD method_24381 calculateDistanceTo (Lnet/minecraft/class_1959$class_4762;)F
 			COMMENT Calculates the distance from this noise point to another one. The
 			COMMENT distance is a squared distance in a multi-dimensional cartesian plane

--- a/mappings/net/minecraft/world/biome/BiomeEffects.mapping
+++ b/mappings/net/minecraft/world/biome/BiomeEffects.mapping
@@ -40,6 +40,7 @@ CLASS net/minecraft/class_4763 net/minecraft/world/biome/BiomeEffects
 		COMMENT
 		COMMENT <p>An additions sound is played at 1.1% chance every tick as an ambient
 		COMMENT sound whenever the player is in the biome with this effect.
+	METHOD method_27345 getMusic ()Ljava/util/Optional;
 	CLASS class_4764 Builder
 		FIELD field_22071 fogColor Ljava/util/OptionalInt;
 		FIELD field_22072 waterColor Ljava/util/OptionalInt;

--- a/mappings/net/minecraft/world/biome/BiomeParticleConfig.mapping
+++ b/mappings/net/minecraft/world/biome/BiomeParticleConfig.mapping
@@ -1,5 +1,10 @@
 CLASS net/minecraft/class_4761 net/minecraft/world/biome/BiomeParticleConfig
 	FIELD field_22035 chance F
 	FIELD field_24675 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24676 particle Lnet/minecraft/class_2394;
+	METHOD <init> (Lnet/minecraft/class_2394;F)V
+		ARG 1 particle
+		ARG 2 chance
 	METHOD method_24369 getParticleType ()Lnet/minecraft/class_2394;
 	METHOD method_24370 shouldAddParticle (Ljava/util/Random;)Z
+		ARG 1 random

--- a/mappings/net/minecraft/world/biome/FrozenOceanBiome.mapping
+++ b/mappings/net/minecraft/world/biome/FrozenOceanBiome.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_1995 net/minecraft/world/biome/FrozenOceanBiome
+	FIELD field_9487 biomeNoise Lnet/minecraft/class_3543;

--- a/mappings/net/minecraft/world/biome/layer/EaseBiomeEdgeLayer.mapping
+++ b/mappings/net/minecraft/world/biome/layer/EaseBiomeEdgeLayer.mapping
@@ -15,3 +15,8 @@ CLASS net/minecraft/class_3641 net/minecraft/world/biome/layer/EaseBiomeEdgeLaye
 	FIELD field_16099 PLAINS_ID I
 	FIELD field_16100 WOODED_BADLANDS_PLATEAU_ID I
 	FIELD field_16101 BADLANDS_PLATEAU_ID I
+	METHOD method_15839 isValidTemperatureEdge (II)Z
+		ARG 1 id1
+		ARG 2 id2
+	METHOD method_15840 areEdgesSimilar ([IIIIIIII)Z
+	METHOD method_15841 isMountainBiome ([IIIIIIII)Z

--- a/mappings/net/minecraft/world/biome/layer/ScaleLayer.mapping
+++ b/mappings/net/minecraft/world/biome/layer/ScaleLayer.mapping
@@ -1,3 +1,7 @@
 CLASS net/minecraft/class_3656 net/minecraft/world/biome/layer/ScaleLayer
 	METHOD method_15853 sample (Lnet/minecraft/class_3628;IIII)I
 		ARG 1 context
+		ARG 2 a
+		ARG 3 b
+		ARG 4 c
+		ARG 5 d

--- a/mappings/net/minecraft/world/biome/source/BiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/BiomeSource.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1966 net/minecraft/world/biome/source/BiomeSource
 	FIELD field_20643 biomes Ljava/util/List;
+	FIELD field_24713 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_9390 topMaterials Ljava/util/Set;
 	FIELD field_9391 SPAWN_BIOMES Ljava/util/List;
 	FIELD field_9392 structureFeatures Ljava/util/Map;
@@ -14,6 +15,7 @@ CLASS net/minecraft/class_1966 net/minecraft/world/biome/source/BiomeSource
 		ARG 7 random
 	METHOD method_27985 withSeed (J)Lnet/minecraft/class_1966;
 		ARG 1 seed
+	METHOD method_28442 getCodec ()Lcom/mojang/serialization/Codec;
 	METHOD method_28443 getBiomes ()Ljava/util/List;
 	METHOD method_8754 hasStructureFeature (Lnet/minecraft/class_3195;)Z
 		ARG 1 feature

--- a/mappings/net/minecraft/world/biome/source/CheckerboardBiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/CheckerboardBiomeSource.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_1973 net/minecraft/world/biome/source/CheckerboardBiomeSource
+	FIELD field_24715 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24716 scale I
 	FIELD field_9480 gridSize I
 	FIELD field_9481 biomeArray Ljava/util/List;
 	METHOD <init> (Ljava/util/List;I)V

--- a/mappings/net/minecraft/world/biome/source/FixedBiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/FixedBiomeSource.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_1992 net/minecraft/world/biome/source/FixedBiomeSource
+	FIELD field_24717 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_9486 biome Lnet/minecraft/class_1959;

--- a/mappings/net/minecraft/world/biome/source/MultiNoiseBiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/MultiNoiseBiomeSource.mapping
@@ -16,6 +16,7 @@ CLASS net/minecraft/class_4766 net/minecraft/world/biome/source/MultiNoiseBiomeS
 		ARG 0 biome
 	METHOD method_27988 (Lnet/minecraft/class_1959;Lnet/minecraft/class_1959$class_4762;)Lcom/mojang/datafixers/util/Pair;
 		ARG 1 point
+	METHOD method_28462 matchesInstance (J)Z
 	CLASS class_5305 Preset
 		FIELD field_24722 CODEC Lcom/mojang/serialization/MapCodec;
 		FIELD field_24723 NETHER Lnet/minecraft/class_4766$class_5305;

--- a/mappings/net/minecraft/world/biome/source/TheEndBiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/TheEndBiomeSource.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2169 net/minecraft/world/biome/source/TheEndBiomeSource
 	FIELD field_9830 BIOMES Ljava/util/List;
 	FIELD field_9831 noise Lnet/minecraft/class_3541;
+	METHOD method_28479 matches (J)Z
 	METHOD method_8757 getNoiseAt (Lnet/minecraft/class_3541;II)F

--- a/mappings/net/minecraft/world/biome/source/VanillaLayeredBiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/VanillaLayeredBiomeSource.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_2088 net/minecraft/world/biome/source/VanillaLayeredBiomeSource
+	FIELD field_24498 legacyBiomeInitLayer Z
 	FIELD field_24727 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24728 seed J
+	FIELD field_24729 largeBiomes Z
 	FIELD field_9677 BIOMES Ljava/util/List;
 	FIELD field_9680 biomeSampler Lnet/minecraft/class_3642;
+	METHOD <init> (JZZ)V
+		ARG 1 seed
+		ARG 4 largeBiomes

--- a/mappings/net/minecraft/world/border/WorldBorder.mapping
+++ b/mappings/net/minecraft/world/border/WorldBorder.mapping
@@ -96,6 +96,7 @@ CLASS net/minecraft/class_2784 net/minecraft/world/border/WorldBorder
 		FIELD field_17653 shape Lnet/minecraft/class_265;
 		METHOD <init> (Lnet/minecraft/class_2784;D)V
 			ARG 1 size
+			ARG 2 newSize
 		METHOD method_11996 recalculateBounds ()V
 	CLASS class_5200 Properties
 		FIELD field_24123 centerX D
@@ -123,6 +124,8 @@ CLASS net/minecraft/class_2784 net/minecraft/world/border/WorldBorder
 		METHOD method_27357 toTag (Lnet/minecraft/class_2487;)V
 			ARG 1 tag
 		METHOD method_27358 fromDynamic (Lcom/mojang/serialization/DynamicLike;Lnet/minecraft/class_2784$class_5200;)Lnet/minecraft/class_2784$class_5200;
+			ARG 0 dynamicLike
+			ARG 1 properties
 		METHOD method_27359 getCenterZ ()D
 		METHOD method_27360 getDamagePerBlock ()D
 		METHOD method_27361 getBuffer ()D

--- a/mappings/net/minecraft/world/chunk/ChunkCache.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkCache.mapping
@@ -8,3 +8,8 @@ CLASS net/minecraft/class_1950 net/minecraft/world/chunk/ChunkCache
 		ARG 1 world
 		ARG 2 minPos
 		ARG 3 maxPos
+	METHOD method_22353 getChunk (II)Lnet/minecraft/class_2791;
+		ARG 1 chunkX
+		ARG 2 chunkY
+	METHOD method_22354 getChunk (Lnet/minecraft/class_2338;)Lnet/minecraft/class_2791;
+		ARG 1 pos

--- a/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
@@ -1,5 +1,9 @@
 CLASS net/minecraft/class_2804 net/minecraft/world/chunk/ChunkNibbleArray
 	FIELD field_12783 byteArray [B
+	METHOD <init> (I)V
+		ARG 1 length
+	METHOD <init> ([B)V
+		ARG 1 byteArray
 	METHOD method_12137 asByteArray ()[B
 	METHOD method_12138 divideByTwo (I)I
 		ARG 1 n
@@ -12,6 +16,7 @@ CLASS net/minecraft/class_2804 net/minecraft/world/chunk/ChunkNibbleArray
 		ARG 2 y
 		ARG 3 z
 	METHOD method_12141 get (I)I
+		ARG 1 index
 	METHOD method_12142 set (II)V
 		ARG 1 index
 		ARG 2 value

--- a/mappings/net/minecraft/world/chunk/ColumnChunkNibbleArray.mapping
+++ b/mappings/net/minecraft/world/chunk/ColumnChunkNibbleArray.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_4298 net/minecraft/world/chunk/ColumnChunkNibbleArray
+	METHOD <init> (Lnet/minecraft/class_2804;I)V
+		ARG 1 chunkNibbleArray
+		ARG 2 length

--- a/mappings/net/minecraft/world/chunk/Palette.mapping
+++ b/mappings/net/minecraft/world/chunk/Palette.mapping
@@ -11,3 +11,4 @@ CLASS net/minecraft/class_2837 net/minecraft/world/chunk/Palette
 	METHOD method_12291 getIndex (Ljava/lang/Object;)I
 		ARG 1 object
 	METHOD method_19525 accepts (Ljava/util/function/Predicate;)Z
+		ARG 1 predicate

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -40,6 +40,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 1 paletteTag
 		ARG 2 data
 	METHOD method_12330 write (Lnet/minecraft/class_2487;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 1 tag
 	METHOD method_12331 get (I)Ljava/lang/Object;
 		ARG 1 index
 	METHOD method_12332 (Ljava/lang/Thread;)Ljava/lang/String;
@@ -57,6 +58,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 2 y
 		ARG 3 z
 		ARG 4 value
+	METHOD method_19526 hasAny (Ljava/util/function/Predicate;)Z
 	METHOD method_21732 count (Lnet/minecraft/class_2841$class_4464;)V
 		ARG 1 consumer
 	CLASS class_4464 CountConsumer

--- a/mappings/net/minecraft/world/chunk/UpgradeData.mapping
+++ b/mappings/net/minecraft/world/chunk/UpgradeData.mapping
@@ -27,8 +27,17 @@ CLASS net/minecraft/class_2843 net/minecraft/world/chunk/UpgradeData
 		METHOD method_12357 postUpdate (Lnet/minecraft/class_1936;)V
 			ARG 1 world
 		METHOD method_12358 getUpdatedState (Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
+			ARG 1 oldState
+			ARG 2 direction
+			ARG 3 newState
+			ARG 4 world
+			ARG 5 currentPos
+			ARG 6 otherPos
 	CLASS class_2845 BuiltinLogic
 		FIELD field_12959 DIRECTIONS [Lnet/minecraft/class_2350;
+		METHOD <init> (Ljava/lang/String;IZ[Lnet/minecraft/class_2248;)V
+			ARG 3 postUpdate
+			ARG 4 blocks
 		METHOD <init> (Ljava/lang/String;I[Lnet/minecraft/class_2248;)V
 			ARG 3 blocks
 		CLASS 4

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvider
 	FIELD field_15792 type Lnet/minecraft/class_1944;
 	FIELD field_15793 lightStorage Lnet/minecraft/class_3560;
+	FIELD field_15794 runningLightUpdates Z
 	FIELD field_15795 chunkProvider Lnet/minecraft/class_2823;
 	FIELD field_16513 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_17397 cachedChunkPositions [J
@@ -50,3 +51,4 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 1 world
 		ARG 2 pos
 		ARG 4 facing
+	METHOD method_22875 displaySectionLevel (J)Ljava/lang/String;

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightingView.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightingView.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_3562 net/minecraft/world/chunk/light/ChunkLightingView
 	METHOD method_15543 getLightLevel (Lnet/minecraft/class_2338;)I
+		ARG 1 pos
 	METHOD method_15544 getLightArray (Lnet/minecraft/class_4076;)Lnet/minecraft/class_2804;
 		ARG 1 pos
 	CLASS class_3563 Empty

--- a/mappings/net/minecraft/world/chunk/light/LevelPropagator.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LevelPropagator.mapping
@@ -65,6 +65,8 @@ CLASS net/minecraft/class_3554 net/minecraft/world/chunk/light/LevelPropagator
 		ARG 5 removeFully
 	METHOD method_15494 isMarker (J)Z
 		ARG 1 id
+	METHOD method_24206 removePendingUpdateIf (Ljava/util/function/LongPredicate;)V
+	METHOD method_24208 getPendingUpdateCount ()I
 	CLASS 1
 		METHOD rehash (I)V
 			ARG 1 newN

--- a/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
@@ -1,15 +1,20 @@
 CLASS net/minecraft/class_3560 net/minecraft/world/chunk/light/LightStorage
 	FIELD field_15796 lightArrays Lnet/minecraft/class_3556;
+	FIELD field_15797 markedNotReadySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15798 lightArraysToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15799 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_15800 hasLightUpdates Z
 	FIELD field_15801 EMPTY Lnet/minecraft/class_2804;
+	FIELD field_15802 dirtySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15803 chunkProvider Lnet/minecraft/class_2823;
+	FIELD field_15804 markedReadySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15805 lightType Lnet/minecraft/class_1944;
 	FIELD field_15806 uncachedLightArrays Lnet/minecraft/class_3556;
 	FIELD field_15807 lightArraysToAdd Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
 	FIELD field_15808 nonEmptySections Lit/unimi/dsi/fastutil/longs/LongSet;
-	FIELD field_16448 dirtySections Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_16448 notifySections Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_19342 columnsToRetain Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_25621 queuedEdgeSections Lit/unimi/dsi/fastutil/longs/LongSet;
 	METHOD <init> (Lnet/minecraft/class_1944;Lnet/minecraft/class_2823;Lnet/minecraft/class_3556;)V
 		ARG 1 lightType
 		ARG 2 chunkProvider
@@ -28,6 +33,7 @@ CLASS net/minecraft/class_3560 net/minecraft/world/chunk/light/LightStorage
 		ARG 1 pos
 		ARG 3 empty
 	METHOD method_15527 updateLightArrays (Lnet/minecraft/class_3558;ZZ)V
+		ARG 1 storage
 		ARG 2 doSkylight
 		ARG 3 skipEdgeLightPropagation
 	METHOD method_15528 hasLightUpdates ()Z
@@ -53,3 +59,6 @@ CLASS net/minecraft/class_3560 net/minecraft/world/chunk/light/LightStorage
 	METHOD method_20533 getLightArray (J)Lnet/minecraft/class_2804;
 		ARG 1 sectionPos
 	METHOD method_20600 setRetainData (JZ)V
+	METHOD method_29967 updateSection (Lnet/minecraft/class_3558;J)V
+		ARG 1 storage
+		ARG 2 sectionPos

--- a/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/class_3569 net/minecraft/world/chunk/light/SkyLightStorage
 	FIELD field_15815 pendingSkylightUpdates Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15816 sectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15817 lightEnabled Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15818 LIGHT_REDUCTION_DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_15819 hasSkyLightUpdates Z
+	FIELD field_15820 sectionsWithStorage Lit/unimi/dsi/fastutil/longs/LongSet;
 	METHOD <init> (Lnet/minecraft/class_2823;)V
 		ARG 1 chunkProvider
 	METHOD method_15566 isLightEnabled (J)Z
@@ -12,6 +14,8 @@ CLASS net/minecraft/class_3569 net/minecraft/world/chunk/light/SkyLightStorage
 	METHOD method_15568 isAboveTopmostLightArray (J)Z
 		ARG 1 pos
 	METHOD method_15569 checkForUpdates ()V
+	METHOD method_20809 enqueueRemoveSection (J)V
+	METHOD method_20810 enqueueAddSection (J)V
 	CLASS class_3570 Data
 		FIELD field_15821 topArraySectionY Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;
 		FIELD field_15822 defaultTopArraySectionY I

--- a/mappings/net/minecraft/world/dimension/DimensionOptions.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionOptions.mapping
@@ -8,8 +8,12 @@ CLASS net/minecraft/class_5363 net/minecraft/world/dimension/DimensionOptions
 	FIELD field_25417 chunkGenerator Lnet/minecraft/class_2794;
 	METHOD <init> (Ljava/util/function/Supplier;Lnet/minecraft/class_2794;)V
 		ARG 1 typeSupplier
+		ARG 2 chunkGenerator
 	METHOD method_29566 getDimensionTypeSupplier ()Ljava/util/function/Supplier;
-	METHOD method_29567 (JLnet/minecraft/class_2370;)Z
+	METHOD method_29567 hasDefaultSettings (JLnet/minecraft/class_2370;)Z
 		ARG 0 seed
+		ARG 2 registry
+	METHOD method_29569 createRegistry (Lnet/minecraft/class_2370;)Lnet/minecraft/class_2370;
+		ARG 0 registry
 	METHOD method_29570 getDimensionType ()Lnet/minecraft/class_2874;
 	METHOD method_29571 getChunkGenerator ()Lnet/minecraft/class_2794;

--- a/mappings/net/minecraft/world/dimension/DimensionType.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionType.mapping
@@ -3,15 +3,18 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 	FIELD field_20658 biomeAccessType Lnet/minecraft/class_4545;
 	FIELD field_24504 hasCeiling Z
 	FIELD field_24505 ultrawarm Z
+	FIELD field_24752 MOON_SIZES [F
 	FIELD field_24753 OVERWORLD_REGISTRY_KEY Lnet/minecraft/class_5321;
 	FIELD field_24754 THE_NETHER_REGISTRY_KEY Lnet/minecraft/class_5321;
 	FIELD field_24755 THE_END_REGISTRY_KEY Lnet/minecraft/class_5321;
+	FIELD field_24756 REGISTRY_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_24757 CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD field_24761 fixedTime Ljava/util/OptionalLong;
 	FIELD field_24762 natural Z
 	FIELD field_24763 shrunk Z
 	FIELD field_24764 hasEnderDragonFight Z
 	FIELD field_24766 ambientLight F
+	FIELD field_24767 brightnessByLightLevel [F
 	FIELD field_25407 OVERWORLD Lnet/minecraft/class_2874;
 	FIELD field_25408 THE_NETHER Lnet/minecraft/class_2874;
 	FIELD field_25409 THE_END Lnet/minecraft/class_2874;
@@ -61,10 +64,20 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 	METHOD method_22415 getBiomeAccessType ()Lnet/minecraft/class_4545;
 	METHOD method_27998 hasCeiling ()Z
 	METHOD method_27999 isUltrawarm ()Z
-	METHOD method_28517 (J)Lnet/minecraft/class_2370;
+	METHOD method_28515 computeBrightnessByLightLevel (F)[F
+		ARG 0 time
+	METHOD method_28516 getBrightness (I)F
+		ARG 1 time
+	METHOD method_28517 createDefaultDimensionOptions (J)Lnet/minecraft/class_2370;
 		ARG 0 seed
+	METHOD method_28521 worldFromDimensionNbt (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/DataResult;
+		ARG 0 dynamic
 	METHOD method_28523 addRegistryDefaults (Lnet/minecraft/class_5318$class_5319;)Lnet/minecraft/class_5318$class_5319;
 		ARG 0 registryTracker
+	METHOD method_28528 getSkyAngle (J)F
+		ARG 1 time
+	METHOD method_28531 getMoonPhase (J)I
+		ARG 1 time
 	METHOD method_28533 createEndGenerator (J)Lnet/minecraft/class_2794;
 		ARG 0 seed
 	METHOD method_28535 createNetherGenerator (J)Lnet/minecraft/class_2794;

--- a/mappings/net/minecraft/world/explosion/Explosion.mapping
+++ b/mappings/net/minecraft/world/explosion/Explosion.mapping
@@ -20,6 +20,15 @@ CLASS net/minecraft/class_1927 net/minecraft/world/explosion/Explosion
 		ARG 7 z
 		ARG 9 power
 		ARG 10 affectedBlocks
+	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;DDDFZLnet/minecraft/class_1927$class_4179;)V
+		ARG 1 world
+		ARG 2 entity
+		ARG 3 x
+		ARG 5 y
+		ARG 7 z
+		ARG 9 power
+		ARG 10 createFire
+		ARG 11 destructionType
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;DDDFZLnet/minecraft/class_1927$class_4179;Ljava/util/List;)V
 		ARG 1 world
 		ARG 2 entity
@@ -33,9 +42,18 @@ CLASS net/minecraft/class_1927 net/minecraft/world/explosion/Explosion
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;Lnet/minecraft/class_1282;Lnet/minecraft/class_5362;DDDFZLnet/minecraft/class_1927$class_4179;)V
 		ARG 1 world
 		ARG 2 entity
+		ARG 3 damageSource
+		ARG 4 behavior
+		ARG 5 x
+		ARG 7 y
+		ARG 9 z
+		ARG 11 power
+		ARG 12 createFire
+		ARG 13 destructionType
 	METHOD method_17752 getExposure (Lnet/minecraft/class_243;Lnet/minecraft/class_1297;)F
 		ARG 0 source
 		ARG 1 entity
+	METHOD method_24023 tryMergeStack (Lit/unimi/dsi/fastutil/objects/ObjectArrayList;Lnet/minecraft/class_1799;Lnet/minecraft/class_2338;)V
 	METHOD method_29553 chooseBehavior (Lnet/minecraft/class_1297;)Lnet/minecraft/class_5362;
 		ARG 1 entity
 	METHOD method_8346 getAffectedBlocks ()Ljava/util/List;
@@ -43,6 +61,7 @@ CLASS net/minecraft/class_1927 net/minecraft/world/explosion/Explosion
 	METHOD method_8348 collectBlocksAndDamageEntities ()V
 	METHOD method_8349 getDamageSource ()Lnet/minecraft/class_1282;
 	METHOD method_8350 affectWorld (Z)V
+		ARG 1 particles
 	METHOD method_8351 getAffectedPlayers ()Ljava/util/Map;
 	METHOD method_8352 clearAffectedBlocks ()V
 	CLASS class_4179 DestructionType

--- a/mappings/net/minecraft/world/gen/GenerationStep.mapping
+++ b/mappings/net/minecraft/world/gen/GenerationStep.mapping
@@ -2,9 +2,12 @@ CLASS net/minecraft/class_2893 net/minecraft/world/gen/GenerationStep
 	CLASS class_2894 Carver
 		FIELD field_13167 name Ljava/lang/String;
 		FIELD field_13168 BY_NAME Ljava/util/Map;
+		FIELD field_24770 CODEC Lcom/mojang/serialization/Codec;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
 		METHOD method_12581 getName ()Ljava/lang/String;
+		METHOD method_28546 byName (Ljava/lang/String;)Lnet/minecraft/class_2893$class_2894;
+			ARG 0 name
 	CLASS class_2895 Feature
 		FIELD field_13175 BY_NAME Ljava/util/Map;
 		FIELD field_13180 name Ljava/lang/String;
@@ -12,3 +15,5 @@ CLASS net/minecraft/class_2893 net/minecraft/world/gen/GenerationStep
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
 		METHOD method_12582 getName ()Ljava/lang/String;
+		METHOD method_28547 byName (Ljava/lang/String;)Lnet/minecraft/class_2893$class_2895;
+			ARG 0 name

--- a/mappings/net/minecraft/world/gen/GeneratorOptions.mapping
+++ b/mappings/net/minecraft/world/gen/GeneratorOptions.mapping
@@ -12,13 +12,16 @@ CLASS net/minecraft/class_5285 net/minecraft/world/gen/GeneratorOptions
 		ARG 1 seed
 		ARG 3 generateStructures
 		ARG 4 bonusChest
+		ARG 5 registry
 	METHOD <init> (JZZLnet/minecraft/class_2370;Ljava/util/Optional;)V
 		ARG 1 seed
 		ARG 3 generateStructures
 		ARG 4 bonusChest
+		ARG 5 options
 		ARG 6 legacyCustomOptions
 	METHOD method_28009 getDefaultOptions ()Lnet/minecraft/class_5285;
 	METHOD method_28021 fromProperties (Ljava/util/Properties;)Lnet/minecraft/class_5285;
+		ARG 0 properties
 	METHOD method_28024 withHardcore (ZLjava/util/OptionalLong;)Lnet/minecraft/class_5285;
 		ARG 1 hardcore
 		ARG 2 seed
@@ -34,5 +37,16 @@ CLASS net/minecraft/class_5285 net/minecraft/world/gen/GeneratorOptions
 	METHOD method_28038 toggleBonusChest ()Lnet/minecraft/class_5285;
 	METHOD method_28604 createOverworldGenerator (J)Lnet/minecraft/class_3754;
 		ARG 0 seed
+	METHOD method_28608 getRegistryWithReplacedOverworldGenerator (Lnet/minecraft/class_2370;Lnet/minecraft/class_2794;)Lnet/minecraft/class_2370;
+		ARG 0 registry
+		ARG 1 generator
 	METHOD method_28609 getDimensionMap ()Lnet/minecraft/class_2370;
+	METHOD method_28610 validate ()Lcom/mojang/serialization/DataResult;
+	METHOD method_28611 isStable ()Z
+	METHOD method_29573 withDimensions (Lnet/minecraft/class_2370;)Lnet/minecraft/class_5285;
+		ARG 1 registry
 	METHOD method_29575 getWorlds ()Lcom/google/common/collect/ImmutableSet;
+	METHOD method_29962 getRegistryWithReplacedOverworld (Lnet/minecraft/class_2370;Ljava/util/function/Supplier;Lnet/minecraft/class_2794;)Lnet/minecraft/class_2370;
+		ARG 0 registry
+		ARG 1 typeSupplier
+		ARG 2 generator

--- a/mappings/net/minecraft/world/gen/PillagerSpawner.mapping
+++ b/mappings/net/minecraft/world/gen/PillagerSpawner.mapping
@@ -1,3 +1,7 @@
 CLASS net/minecraft/class_3769 net/minecraft/world/gen/PillagerSpawner
 	FIELD field_16652 ticksUntilNextSpawn I
 	METHOD method_16575 spawnOneEntity (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;Z)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 random
+		ARG 4 patrolLeader

--- a/mappings/net/minecraft/world/gen/Spawner.mapping
+++ b/mappings/net/minecraft/world/gen/Spawner.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_5304 net/minecraft/world/gen/Spawner
 	METHOD method_6445 spawn (Lnet/minecraft/class_3218;ZZ)I
+		ARG 1 world
+		ARG 2 spawnMonsters
+		ARG 3 spawnAnimals

--- a/mappings/net/minecraft/world/gen/StructureAccessor.mapping
+++ b/mappings/net/minecraft/world/gen/StructureAccessor.mapping
@@ -32,7 +32,11 @@ CLASS net/minecraft/class_5138 net/minecraft/world/gen/StructureAccessor
 		ARG 1 piece
 	METHOD method_28387 (Lnet/minecraft/class_2338;Lnet/minecraft/class_3449;)Z
 		ARG 1 structureStart
+	METHOD method_28388 getStructureAt (Lnet/minecraft/class_2338;ZLnet/minecraft/class_3195;)Lnet/minecraft/class_3449;
+		ARG 1 pos
+		ARG 2 onlyStart
+		ARG 3 feature
 	METHOD method_28389 (ZLnet/minecraft/class_2338;Lnet/minecraft/class_3449;)Z
 		ARG 2 structureStart
-	METHOD method_29951 (Lnet/minecraft/class_3233;)Lnet/minecraft/class_5138;
+	METHOD method_29951 forRegion (Lnet/minecraft/class_3233;)Lnet/minecraft/class_5138;
 		ARG 1 region

--- a/mappings/net/minecraft/world/gen/carver/ConfiguredCarver.mapping
+++ b/mappings/net/minecraft/world/gen/carver/ConfiguredCarver.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_2922 net/minecraft/world/gen/carver/ConfiguredCarver
 	FIELD field_13278 config Lnet/minecraft/class_2920;
 	FIELD field_13279 carver Lnet/minecraft/class_2939;
+	FIELD field_24828 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_2939;Lnet/minecraft/class_2920;)V
 		ARG 1 carver
 		ARG 2 config

--- a/mappings/net/minecraft/world/gen/carver/DefaultCarverConfig.mapping
+++ b/mappings/net/minecraft/world/gen/carver/DefaultCarverConfig.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_2932 net/minecraft/world/gen/carver/DefaultCarverConfig
+	FIELD field_24829 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24830 INSTANCE Lnet/minecraft/class_2932;

--- a/mappings/net/minecraft/world/gen/chunk/SurfaceChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/SurfaceChunkGenerator.mapping
@@ -43,3 +43,4 @@ CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/SurfaceChunkGenerat
 		ARG 4 predicate
 	METHOD method_26983 (Lnet/minecraft/class_1923;Lit/unimi/dsi/fastutil/objects/ObjectList;IILit/unimi/dsi/fastutil/objects/ObjectList;Lnet/minecraft/class_3449;)V
 		ARG 5 start
+	METHOD method_28548 matchesSettings (JLnet/minecraft/class_5284$class_5307;)Z

--- a/mappings/net/minecraft/world/gen/feature/AbstractPileFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/AbstractPileFeature.mapping
@@ -2,7 +2,9 @@ CLASS net/minecraft/class_3805 net/minecraft/world/gen/feature/AbstractPileFeatu
 	METHOD method_16707 canPlacePileBlock (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
 		ARG 1 world
 		ARG 2 pos
+		ARG 3 random
 	METHOD method_16708 addPileBlock (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Ljava/util/Random;Lnet/minecraft/class_4634;)V
 		ARG 1 world
 		ARG 2 pos
+		ARG 3 random
 		ARG 4 config

--- a/mappings/net/minecraft/world/gen/feature/BasaltColumnsFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/BasaltColumnsFeature.mapping
@@ -1,1 +1,25 @@
 CLASS net/minecraft/class_5153 net/minecraft/world/gen/feature/BasaltColumnsFeature
+	FIELD field_24132 BLOCKS Lcom/google/common/collect/ImmutableList;
+	METHOD method_27094 moveDownToGround (Lnet/minecraft/class_1936;ILnet/minecraft/class_2338$class_2339;I)Lnet/minecraft/class_2338;
+		ARG 0 world
+		ARG 1 seaLevel
+		ARG 2 pos
+		ARG 3 width
+	METHOD method_27095 isAirOrLavaOcean (Lnet/minecraft/class_1936;ILnet/minecraft/class_2338;)Z
+		ARG 0 world
+		ARG 1 seaLevel
+		ARG 2 pos
+	METHOD method_27096 placeBasaltColumn (Lnet/minecraft/class_1936;ILnet/minecraft/class_2338;II)Z
+		ARG 1 world
+		ARG 2 seaLevel
+		ARG 3 pos
+		ARG 5 width
+	METHOD method_27098 moveUpToAir (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338$class_2339;I)Lnet/minecraft/class_2338;
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_27099 calculateHeight (Ljava/util/Random;Lnet/minecraft/class_5156;)I
+		ARG 0 random
+		ARG 1 config
+	METHOD method_27100 calculateReach (Ljava/util/Random;Lnet/minecraft/class_5156;)I
+		ARG 0 random
+		ARG 1 config

--- a/mappings/net/minecraft/world/gen/feature/BastionRemnantFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/BastionRemnantFeatureConfig.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/class_5186 net/minecraft/world/gen/feature/BastionRemnantFeatureConfig
 	FIELD field_24013 possibleConfigs Ljava/util/List;
 	FIELD field_24889 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Ljava/util/List;)V
+		ARG 1 possibleConfigs
 	METHOD <init> (Ljava/util/Map;)V
 		ARG 1 startPoolToSize
 	METHOD method_27227 getRandom (Ljava/util/Random;)Lnet/minecraft/class_3812;

--- a/mappings/net/minecraft/world/gen/feature/BlockPileFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/BlockPileFeatureConfig.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_4634 net/minecraft/world/gen/feature/BlockPileFeatureConfig
 	FIELD field_21229 stateProvider Lnet/minecraft/class_4651;
 	FIELD field_24873 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lnet/minecraft/class_4651;)V
+		ARG 1 stateProvider

--- a/mappings/net/minecraft/world/gen/feature/ConfiguredFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/ConfiguredFeature.mapping
@@ -2,8 +2,18 @@ CLASS net/minecraft/class_2975 net/minecraft/world/gen/feature/ConfiguredFeature
 	FIELD field_13375 config Lnet/minecraft/class_3037;
 	FIELD field_13376 feature Lnet/minecraft/class_3031;
 	FIELD field_21589 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_24832 NOPE Lnet/minecraft/class_2975;
 	FIELD field_24833 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lnet/minecraft/class_3031;Lnet/minecraft/class_3037;)V
+		ARG 1 feature
+		ARG 2 config
 	METHOD method_12862 generate (Lnet/minecraft/class_5281;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_2338;)Z
+		ARG 1 world
+		ARG 2 structureAccessor
+		ARG 3 generator
+		ARG 4 random
+		ARG 5 pos
 	METHOD method_23387 withChance (F)Lnet/minecraft/class_3226;
 		ARG 1 chance
 	METHOD method_23388 createDecoratedFeature (Lnet/minecraft/class_3243;)Lnet/minecraft/class_2975;
+		ARG 1 decorator

--- a/mappings/net/minecraft/world/gen/feature/ConfiguredStructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/ConfiguredStructureFeature.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_5312 net/minecraft/world/gen/feature/ConfiguredStructureFeature
+	FIELD field_24834 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_24835 structureFeature Lnet/minecraft/class_3195;
 	FIELD field_24836 featureConfig Lnet/minecraft/class_3037;
 	METHOD <init> (Lnet/minecraft/class_3195;Lnet/minecraft/class_3037;)V
@@ -8,5 +9,7 @@ CLASS net/minecraft/class_5312 net/minecraft/world/gen/feature/ConfiguredStructu
 		ARG 1 chunkGenerator
 		ARG 2 biomeSource
 		ARG 3 structureManager
+		ARG 4 seed
 		ARG 6 chunkPos
 		ARG 7 biome
+		ARG 9 config

--- a/mappings/net/minecraft/world/gen/feature/DecoratedFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DecoratedFeatureConfig.mapping
@@ -2,3 +2,6 @@ CLASS net/minecraft/class_2986 net/minecraft/world/gen/feature/DecoratedFeatureC
 	FIELD field_13398 decorator Lnet/minecraft/class_3243;
 	FIELD field_13399 feature Lnet/minecraft/class_2975;
 	FIELD field_24880 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lnet/minecraft/class_2975;Lnet/minecraft/class_3243;)V
+		ARG 1 feature
+		ARG 2 decorator

--- a/mappings/net/minecraft/world/gen/feature/DeltaFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DeltaFeature.mapping
@@ -1,1 +1,16 @@
 CLASS net/minecraft/class_5154 net/minecraft/world/gen/feature/DeltaFeature
+	FIELD field_23883 DIRECTIONS [Lnet/minecraft/class_2350;
+	FIELD field_24133 BLOCKS Lcom/google/common/collect/ImmutableList;
+	METHOD method_27102 findDeltaLevel (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338$class_2339;)Lnet/minecraft/class_2338;
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_27103 canPlace (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_5158;)Z
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 config
+	METHOD method_27104 calculateRadius (Ljava/util/Random;Lnet/minecraft/class_5158;)I
+		ARG 0 random
+		ARG 1 config
+	METHOD method_27105 calcuateRimSize (Ljava/util/Random;Lnet/minecraft/class_5158;)I
+		ARG 0 random
+		ARG 1 config

--- a/mappings/net/minecraft/world/gen/feature/EndSpikeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/EndSpikeFeature.mapping
@@ -1,10 +1,12 @@
 CLASS net/minecraft/class_3310 net/minecraft/world/gen/feature/EndSpikeFeature
 	FIELD field_14309 CACHE Lcom/google/common/cache/LoadingCache;
 	METHOD method_14506 getSpikes (Lnet/minecraft/class_5281;)Ljava/util/List;
+		ARG 0 world
 	METHOD method_15888 generateSpike (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_3666;Lnet/minecraft/class_3310$class_3181;)V
 		ARG 1 world
 		ARG 2 random
 		ARG 3 config
+		ARG 4 spike
 	CLASS class_3181 Spike
 		FIELD field_13831 height I
 		FIELD field_13832 guarded Z
@@ -18,6 +20,7 @@ CLASS net/minecraft/class_3310 net/minecraft/world/gen/feature/EndSpikeFeature
 			ARG 2 centerZ
 			ARG 3 radius
 			ARG 4 height
+			ARG 5 guarded
 		METHOD method_13962 isInChunk (Lnet/minecraft/class_2338;)Z
 			ARG 1 pos
 		METHOD method_13963 getRadius ()I
@@ -27,3 +30,5 @@ CLASS net/minecraft/class_3310 net/minecraft/world/gen/feature/EndSpikeFeature
 		METHOD method_13967 getCenterZ ()I
 		METHOD method_13968 getBoundingBox ()Lnet/minecraft/class_238;
 	CLASS class_3311 SpikeCache
+		METHOD load load (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 seed

--- a/mappings/net/minecraft/world/gen/feature/EndSpikeFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/EndSpikeFeatureConfig.mapping
@@ -3,6 +3,10 @@ CLASS net/minecraft/class_3666 net/minecraft/world/gen/feature/EndSpikeFeatureCo
 	FIELD field_16207 crystalInvulnerable Z
 	FIELD field_16208 spikes Ljava/util/List;
 	FIELD field_24911 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (ZLjava/util/List;Ljava/util/Optional;)V
+		ARG 1 crystalInvulnerable
+		ARG 2 spikes
+		ARG 3 crystalBeamTarget
 	METHOD <init> (ZLjava/util/List;Lnet/minecraft/class_2338;)V
 		ARG 1 crystalInvulnerable
 		ARG 2 spikes

--- a/mappings/net/minecraft/world/gen/feature/FlowerFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/FlowerFeature.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_4624 net/minecraft/world/gen/feature/FlowerFeature
 	METHOD method_13175 getFlowerState (Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_3037;)Lnet/minecraft/class_2680;
+		ARG 1 random
 		ARG 2 pos
 		ARG 3 config
 	METHOD method_23369 isPosValid (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_3037;)Z
@@ -9,5 +10,6 @@ CLASS net/minecraft/class_4624 net/minecraft/world/gen/feature/FlowerFeature
 	METHOD method_23370 getFlowerAmount (Lnet/minecraft/class_3037;)I
 		ARG 1 config
 	METHOD method_23371 getPos (Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_3037;)Lnet/minecraft/class_2338;
+		ARG 1 random
 		ARG 2 pos
 		ARG 3 config

--- a/mappings/net/minecraft/world/gen/feature/HugeFungusFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/HugeFungusFeature.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_4781 net/minecraft/world/gen/feature/HugeFungusFeature
 	METHOD method_24438 getStartPos (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;)Lnet/minecraft/class_2338$class_2339;
 		ARG 0 world
 		ARG 1 pos
+		ARG 2 block
 	METHOD method_24439 generateHatBlock (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_4780;Lnet/minecraft/class_2338$class_2339;FFF)V
 		ARG 1 world
 		ARG 2 random
@@ -14,6 +15,7 @@ CLASS net/minecraft/class_4781 net/minecraft/world/gen/feature/HugeFungusFeature
 		ARG 1 world
 		ARG 2 random
 		ARG 3 config
+		ARG 4 pos
 		ARG 5 stemHeight
 		ARG 6 thickStem
 	METHOD method_24441 tryGenerateVines (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
@@ -22,9 +24,16 @@ CLASS net/minecraft/class_4781 net/minecraft/world/gen/feature/HugeFungusFeature
 		ARG 3 pos
 		ARG 4 state
 	METHOD method_24442 generateVines (Lnet/minecraft/class_2338;Lnet/minecraft/class_1936;Ljava/util/Random;)V
+		ARG 0 pos
+		ARG 1 world
+		ARG 2 random
 	METHOD method_24443 generateHat (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_4780;Lnet/minecraft/class_2338;IZ)V
 		ARG 1 world
 		ARG 2 random
 		ARG 3 config
+		ARG 4 pos
 		ARG 5 hatHeight
 		ARG 6 thickStem
+	METHOD method_24866 isReplaceable (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Z)Z
+		ARG 0 world
+		ARG 1 pos

--- a/mappings/net/minecraft/world/gen/feature/HugeMushroomFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/HugeMushroomFeature.mapping
@@ -9,13 +9,16 @@ CLASS net/minecraft/class_4625 net/minecraft/world/gen/feature/HugeMushroomFeatu
 		ARG 5 config
 	METHOD method_23375 generateCap (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;ILnet/minecraft/class_2338$class_2339;Lnet/minecraft/class_4635;)V
 		ARG 1 world
+		ARG 2 random
 		ARG 3 start
 		ARG 4 y
 		ARG 5 mutable
 		ARG 6 config
 	METHOD method_23376 generateStem (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_4635;ILnet/minecraft/class_2338$class_2339;)V
 		ARG 1 world
+		ARG 2 random
 		ARG 3 pos
 		ARG 4 config
 		ARG 5 height
 	METHOD method_23377 getHeight (Ljava/util/Random;)I
+		ARG 1 random

--- a/mappings/net/minecraft/world/gen/feature/IcebergFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/IcebergFeature.mapping
@@ -2,11 +2,39 @@ CLASS net/minecraft/class_3074 net/minecraft/world/gen/feature/IcebergFeature
 	METHOD method_13414 isAirBelow (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 1 world
 		ARG 2 pos
-	METHOD method_13418 (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;IIZI)V
+	METHOD method_13415 carve (IILnet/minecraft/class_2338;Lnet/minecraft/class_1936;ZDLnet/minecraft/class_2338;II)V
+		ARG 4 world
+		ARG 8 pos
+	METHOD method_13416 decreaseValueNearTop (III)I
+	METHOD method_13417 heightDependentRadiusEllipse (III)I
+	METHOD method_13418 smooth (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;IIZI)V
 		ARG 1 world
 		ARG 2 pos
+	METHOD method_13419 heightDependentRadiusRound (Ljava/util/Random;III)I
+		ARG 1 random
 	METHOD method_13420 isSnowyOrIcy (Lnet/minecraft/class_2248;)Z
 		ARG 1 block
+	METHOD method_13421 signedDistanceCircle (IILnet/minecraft/class_2338;ILjava/util/Random;)D
+		ARG 3 pos
+		ARG 5 random
 	METHOD method_13422 clearSnowAbove (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;)V
 		ARG 1 world
 		ARG 2 pos
+	METHOD method_13424 getDistance (IILnet/minecraft/class_2338;IID)D
+		ARG 3 pos
+	METHOD method_13425 placeBlockOrSnow (Lnet/minecraft/class_2338;Lnet/minecraft/class_1936;Ljava/util/Random;IIZZLnet/minecraft/class_2680;)V
+		ARG 1 pos
+		ARG 2 world
+		ARG 3 random
+		ARG 8 state
+	METHOD method_13426 placeAt (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;IIIIIIZIDZLnet/minecraft/class_2680;)V
+		ARG 1 world
+		ARG 2 random
+		ARG 3 pos
+		ARG 15 state
+	METHOD method_13427 heightDependentRadiusSteep (Ljava/util/Random;III)I
+		ARG 1 random
+	METHOD method_13428 generateCutOut (Ljava/util/Random;Lnet/minecraft/class_1936;IILnet/minecraft/class_2338;ZIDI)V
+		ARG 1 random
+		ARG 2 world
+		ARG 5 pos

--- a/mappings/net/minecraft/world/gen/feature/NetherForestVegetationFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/NetherForestVegetationFeature.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_4782 net/minecraft/world/gen/feature/NetherForestVegetationFeature
+	METHOD method_26264 generate (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_4634;II)Z
+		ARG 0 world
+		ARG 1 random
+		ARG 2 pos
+		ARG 3 config

--- a/mappings/net/minecraft/world/gen/feature/NetherrackReplaceBlobsFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/NetherrackReplaceBlobsFeature.mapping
@@ -1,1 +1,8 @@
 CLASS net/minecraft/class_5155 net/minecraft/world/gen/feature/NetherrackReplaceBlobsFeature
+	METHOD method_27107 moveDownToTarget (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338$class_2339;Lnet/minecraft/class_2248;)Lnet/minecraft/class_2338;
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 block
+	METHOD method_27108 calculateReach (Ljava/util/Random;Lnet/minecraft/class_5160;)Lnet/minecraft/class_2382;
+		ARG 0 random
+		ARG 1 config

--- a/mappings/net/minecraft/world/gen/feature/OceanMonumentFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/OceanMonumentFeature.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_3116 net/minecraft/world/gen/feature/OceanMonumentFeature
 	FIELD field_13716 MONSTER_SPAWNS Ljava/util/List;
 	CLASS class_3117 Start
-		METHOD method_16588 (II)V
+		FIELD field_13717 isCreated Z
+		METHOD method_16588 generatePieces (II)V
 			ARG 1 chunkX
 			ARG 2 chunkZ

--- a/mappings/net/minecraft/world/gen/feature/OceanRuinFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/OceanRuinFeature.mapping
@@ -3,6 +3,9 @@ CLASS net/minecraft/class_3411 net/minecraft/world/gen/feature/OceanRuinFeature
 	CLASS class_3413 BiomeType
 		FIELD field_14529 name Ljava/lang/String;
 		FIELD field_14530 nameMap Ljava/util/Map;
+		FIELD field_24990 CODEC Lcom/mojang/serialization/Codec;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
 		METHOD method_14830 byName (Ljava/lang/String;)Lnet/minecraft/class_3411$class_3413;
 			ARG 0 name
 		METHOD method_14831 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/world/gen/feature/OreFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/OreFeatureConfig.mapping
@@ -11,8 +11,10 @@ CLASS net/minecraft/class_3124 net/minecraft/world/gen/feature/OreFeatureConfig
 		FIELD field_13726 name Ljava/lang/String;
 		FIELD field_13728 nameMap Ljava/util/Map;
 		FIELD field_13731 predicate Ljava/util/function/Predicate;
+		FIELD field_24898 CODEC Lcom/mojang/serialization/Codec;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/function/Predicate;)V
 			ARG 3 name
+			ARG 4 predicate
 		METHOD method_13635 getName ()Ljava/lang/String;
 		METHOD method_13636 getCondition ()Ljava/util/function/Predicate;
 		METHOD method_13638 byName (Ljava/lang/String;)Lnet/minecraft/class_3124$class_3125;

--- a/mappings/net/minecraft/world/gen/feature/RandomFeatureEntry.mapping
+++ b/mappings/net/minecraft/world/gen/feature/RandomFeatureEntry.mapping
@@ -6,3 +6,8 @@ CLASS net/minecraft/class_3226 net/minecraft/world/gen/feature/RandomFeatureEntr
 		ARG 1 feature
 		ARG 2 chance
 	METHOD method_14271 generate (Lnet/minecraft/class_5281;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_2338;)Z
+		ARG 1 world
+		ARG 2 structureAccessor
+		ARG 3 generator
+		ARG 4 random
+		ARG 5 pos

--- a/mappings/net/minecraft/world/gen/feature/RuinedPortalFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/RuinedPortalFeature.mapping
@@ -5,17 +5,23 @@ CLASS net/minecraft/class_5183 net/minecraft/world/gen/feature/RuinedPortalFeatu
 		ARG 0 random
 		ARG 1 min
 		ARG 2 max
+	METHOD method_27209 isColdAt (Lnet/minecraft/class_2338;Lnet/minecraft/class_1959;)Z
+		ARG 0 pos
+		ARG 1 biome
 	METHOD method_27210 choosePlacementHeight (Ljava/util/Random;II)I
+		ARG 0 random
 		ARG 1 min
 		ARG 2 max
-	METHOD method_27211 (Ljava/util/Random;Lnet/minecraft/class_2794;Lnet/minecraft/class_5189$class_5191;ZIILnet/minecraft/class_3341;)I
+	METHOD method_27211 getFloorHeight (Ljava/util/Random;Lnet/minecraft/class_2794;Lnet/minecraft/class_5189$class_5191;ZIILnet/minecraft/class_3341;)I
 		ARG 0 random
 		ARG 1 chunkGenerator
 		ARG 2 verticalPlacement
+		ARG 6 boundingBox
 	CLASS class_5184 Start
 	CLASS class_5185 Type
 		FIELD field_24007 BY_NAME Ljava/util/Map;
 		FIELD field_24008 name Ljava/lang/String;
+		FIELD field_24840 CODEC Lcom/mojang/serialization/Codec;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
 		METHOD method_27214 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/world/gen/feature/SimpleBlockFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/SimpleBlockFeatureConfig.mapping
@@ -4,3 +4,8 @@ CLASS net/minecraft/class_3175 net/minecraft/world/gen/feature/SimpleBlockFeatur
 	FIELD field_13807 toPlace Lnet/minecraft/class_2680;
 	FIELD field_13808 placeOn Ljava/util/List;
 	FIELD field_24909 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lnet/minecraft/class_2680;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+		ARG 1 toPlace
+		ARG 2 placeOn
+		ARG 3 placeIn
+		ARG 4 placeUnder

--- a/mappings/net/minecraft/world/gen/feature/StrongholdFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StrongholdFeature.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_3188 net/minecraft/world/gen/feature/StrongholdFeature
 	CLASS class_3189 Start
+		FIELD field_24559 seed J

--- a/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
@@ -2,20 +2,62 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 	FIELD field_13879 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_24842 STRUCTURES Lcom/google/common/collect/BiMap;
 	FIELD field_24851 SWAMP_HUT Lnet/minecraft/class_3197;
+	FIELD field_24861 JIGSAW_STRUCTURES Ljava/util/List;
 	FIELD field_24862 STRUCTURE_TO_GENERATION_STEP Ljava/util/Map;
+	FIELD field_24863 codec Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lcom/mojang/serialization/Codec;)V
+		ARG 1 codec
 	METHOD method_13149 getMonsterSpawns ()Ljava/util/List;
 	METHOD method_14015 locateStructure (Lnet/minecraft/class_4538;Lnet/minecraft/class_5138;Lnet/minecraft/class_2338;IZJLnet/minecraft/class_5314;)Lnet/minecraft/class_2338;
+		ARG 1 world
+		ARG 2 structureAccessor
+		ARG 3 center
+		ARG 4 radius
 		ARG 5 skipExistingChunks
+		ARG 6 seed
+		ARG 8 config
 	METHOD method_14016 getStructureStartFactory ()Lnet/minecraft/class_3195$class_3774;
 	METHOD method_14019 getName ()Ljava/lang/String;
 	METHOD method_14026 shouldStartAt (Lnet/minecraft/class_2794;Lnet/minecraft/class_1966;JLnet/minecraft/class_2919;IILnet/minecraft/class_1959;Lnet/minecraft/class_1923;Lnet/minecraft/class_3037;)Z
+		ARG 1 generator
+		ARG 2 biomeSource
+		ARG 3 seed
+		ARG 5 chunkRandom
+		ARG 6 chunkX
+		ARG 7 chunkY
+		ARG 8 biome
+		ARG 9 pos
+		ARG 10 config
 	METHOD method_16140 getCreatureSpawns ()Ljava/util/List;
+	METHOD method_27218 getStartChunk (Lnet/minecraft/class_5314;JLnet/minecraft/class_2919;II)Lnet/minecraft/class_1923;
+		ARG 1 config
+		ARG 2 seed
+		ARG 4 chunkRandom
+	METHOD method_27219 isUniformDistribution ()Z
+	METHOD method_28656 createStart (IILnet/minecraft/class_3341;IJ)Lnet/minecraft/class_3449;
+		ARG 1 x
+		ARG 2 y
+		ARG 3 boundingBox
+	METHOD method_28657 tryPlaceStart (Lnet/minecraft/class_2794;Lnet/minecraft/class_1966;Lnet/minecraft/class_3485;JLnet/minecraft/class_1923;Lnet/minecraft/class_1959;ILnet/minecraft/class_2919;Lnet/minecraft/class_5314;Lnet/minecraft/class_3037;)Lnet/minecraft/class_3449;
+		ARG 1 generator
+		ARG 2 biomeSource
+		ARG 3 structureManager
+		ARG 4 seed
+		ARG 6 pos
+		ARG 7 biome
+		ARG 9 chunkRandom
+		ARG 10 config
 	METHOD method_28659 configure (Lnet/minecraft/class_3037;)Lnet/minecraft/class_5312;
 		ARG 1 config
+	METHOD method_28660 readStructureStart (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;J)Lnet/minecraft/class_3449;
+		ARG 1 tag
 	METHOD method_28661 register (Ljava/lang/String;Lnet/minecraft/class_3195;Lnet/minecraft/class_2893$class_2895;)Lnet/minecraft/class_3195;
 		ARG 0 name
 		ARG 1 structureFeature
 		ARG 2 step
+	METHOD method_28663 getGenerationStep ()Lnet/minecraft/class_2893$class_2895;
+	METHOD method_28664 init ()V
+	METHOD method_28665 getCodec ()Lcom/mojang/serialization/Codec;
 	CLASS class_3774 StructureStartFactory
 		METHOD create (Lnet/minecraft/class_3195;IILnet/minecraft/class_3341;IJ)Lnet/minecraft/class_3449;
 			ARG 1 feature

--- a/mappings/net/minecraft/world/gen/feature/StructurePoolFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructurePoolFeatureConfig.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_3812 net/minecraft/world/gen/feature/StructurePoolFeat
 	FIELD field_16861 startPool Lnet/minecraft/class_2960;
 	FIELD field_24886 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_2960;I)V
+		ARG 1 startPool
 		ARG 2 size
 	METHOD method_27222 getSize ()I
 	METHOD method_27223 getStartPool ()Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/world/gen/feature/TreeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/TreeFeature.mapping
@@ -49,4 +49,9 @@ CLASS net/minecraft/class_2944 net/minecraft/world/gen/feature/TreeFeature
 	METHOD method_23384 (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
 	METHOD method_27371 canReplace (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
+		ARG 0 world
 		ARG 1 pos
+	METHOD method_29963 getTopPosition (Lnet/minecraft/class_3746;ILnet/minecraft/class_2338;Lnet/minecraft/class_4643;)I
+		ARG 1 world
+		ARG 3 pos
+		ARG 4 config

--- a/mappings/net/minecraft/world/gen/feature/TwistingVinesFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/TwistingVinesFeature.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_4953 net/minecraft/world/gen/feature/TwistingVinesFeature
 	METHOD method_25986 isNotSuitable (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;)Z
+		ARG 0 world
+		ARG 1 pos
 	METHOD method_25987 generateVineColumn (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338$class_2339;III)V
 		ARG 0 world
 		ARG 1 random
@@ -8,3 +10,13 @@ CLASS net/minecraft/class_4953 net/minecraft/world/gen/feature/TwistingVinesFeat
 		ARG 4 minAge
 		ARG 5 maxAge
 	METHOD method_25988 generateVinesInArea (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;III)V
+		ARG 0 world
+		ARG 1 random
+		ARG 2 pos
+	METHOD method_26265 tryGenerateVines (Lnet/minecraft/class_1936;Ljava/util/Random;Lnet/minecraft/class_2338;III)Z
+		ARG 0 world
+		ARG 1 random
+		ARG 2 pos
+	METHOD method_27220 canGenerate (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338$class_2339;)Z
+		ARG 0 world
+		ARG 1 pos

--- a/mappings/net/minecraft/world/gen/feature/size/FeatureSize.mapping
+++ b/mappings/net/minecraft/world/gen/feature/size/FeatureSize.mapping
@@ -4,5 +4,6 @@ CLASS net/minecraft/class_5201 net/minecraft/world/gen/feature/size/FeatureSize
 	METHOD <init> (Ljava/util/OptionalInt;)V
 		ARG 1 minClippedHeight
 	METHOD method_27377 getMinClippedHeight ()Ljava/util/OptionalInt;
+	METHOD method_27378 getRadius (II)I
 	METHOD method_28820 createCodecBuilder ()Lcom/mojang/serialization/codecs/RecordCodecBuilder;
 	METHOD method_28824 getType ()Lnet/minecraft/class_5202;

--- a/mappings/net/minecraft/world/gen/foliage/BlobFoliagePlacer.mapping
+++ b/mappings/net/minecraft/world/gen/foliage/BlobFoliagePlacer.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_4646 net/minecraft/world/gen/foliage/BlobFoliagePlacer
 	FIELD field_23752 height I
 	FIELD field_24927 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (IIIIILnet/minecraft/class_4648;)V
+		ARG 5 height
+	METHOD method_28838 createCodec (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P5;

--- a/mappings/net/minecraft/world/gen/foliage/FoliagePlacer.mapping
+++ b/mappings/net/minecraft/world/gen/foliage/FoliagePlacer.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_4647 net/minecraft/world/gen/foliage/FoliagePlacer
 	FIELD field_21297 randomRadius I
 	FIELD field_23753 offset I
 	FIELD field_23754 randomOffset I
-	FIELD field_24931 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24931 TYPE_CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (IIII)V
 		ARG 1 radius
 		ARG 2 randomRadius
@@ -18,13 +18,18 @@ CLASS net/minecraft/class_4647 net/minecraft/world/gen/foliage/FoliagePlacer
 		ARG 6 foliageHeight
 		ARG 7 radius
 		ARG 8 leaves
+		ARG 10 boundingBox
 	METHOD method_23449 generate (Lnet/minecraft/class_3747;Ljava/util/Random;Lnet/minecraft/class_4643;Lnet/minecraft/class_2338;ILjava/util/Set;IZLnet/minecraft/class_3341;)V
 		ARG 1 world
 		ARG 2 random
 		ARG 3 config
+		ARG 4 pos
 		ARG 5 baseHeight
+		ARG 7 y
 		ARG 8 giantTrunk
+		ARG 9 boundingBox
 	METHOD method_23451 isInvalidForLeaves (Ljava/util/Random;IIIIZ)Z
+		ARG 1 random
 		ARG 2 baseHeight
 		ARG 3 dx
 		ARG 4 dy
@@ -38,12 +43,19 @@ CLASS net/minecraft/class_4647 net/minecraft/world/gen/foliage/FoliagePlacer
 		ARG 3 config
 	METHOD method_27385 generate (Lnet/minecraft/class_3747;Ljava/util/Random;Lnet/minecraft/class_4643;ILnet/minecraft/class_4647$class_5208;IILjava/util/Set;Lnet/minecraft/class_3341;)V
 		ARG 1 world
+		ARG 2 random
 		ARG 3 config
 		ARG 4 trunkHeight
 		ARG 6 foliageHeight
 		ARG 7 radius
 		ARG 8 leaves
+		ARG 9 boundingBox
+	METHOD method_27386 getRandomOffset (Ljava/util/Random;)I
+		ARG 1 random
+	METHOD method_27387 isPositionInvalid (Ljava/util/Random;IIIIZ)Z
+		ARG 1 random
 	METHOD method_28843 getType ()Lnet/minecraft/class_4648;
+	METHOD method_28846 foliagePlacerParts (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P4;
 	CLASS class_5208 TreeNode
 		COMMENT A point on a tree to generate foliage around
 		FIELD field_24158 center Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/world/gen/foliage/SpruceFoliagePlacer.mapping
+++ b/mappings/net/minecraft/world/gen/foliage/SpruceFoliagePlacer.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_4650 net/minecraft/world/gen/foliage/SpruceFoliagePlacer
 	FIELD field_23757 trunkHeight I
 	FIELD field_23758 randomTrunkHeight I
+	FIELD field_24936 CODEC Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/world/gen/placer/BlockPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/placer/BlockPlacer.mapping
@@ -1,1 +1,8 @@
 CLASS net/minecraft/class_4629 net/minecraft/world/gen/placer/BlockPlacer
+	FIELD field_24865 TYPE_CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_23403 generate (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/Random;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 random
+	METHOD method_28673 getType ()Lnet/minecraft/class_4630;

--- a/mappings/net/minecraft/world/gen/placer/BlockPlacerType.mapping
+++ b/mappings/net/minecraft/world/gen/placer/BlockPlacerType.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_4630 net/minecraft/world/gen/placer/BlockPlacerType
+	FIELD field_24866 codec Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lcom/mojang/serialization/Codec;)V
+		ARG 1 codec
 	METHOD method_23405 register (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/class_4630;
 		ARG 0 id
+		ARG 1 codec
+	METHOD method_28674 getCodec ()Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/world/gen/placer/ColumnPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/placer/ColumnPlacer.mapping
@@ -2,3 +2,6 @@ CLASS net/minecraft/class_4631 net/minecraft/world/gen/placer/ColumnPlacer
 	FIELD field_21227 minSize I
 	FIELD field_21228 extraSize I
 	FIELD field_24867 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (II)V
+		ARG 1 minSize
+		ARG 2 extraSize

--- a/mappings/net/minecraft/world/gen/placer/DoublePlantPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/placer/DoublePlantPlacer.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_4632 net/minecraft/world/gen/placer/DoublePlantPlacer
+	FIELD field_24868 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24869 INSTANCE Lnet/minecraft/class_4632;

--- a/mappings/net/minecraft/world/gen/placer/SimpleBlockPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/placer/SimpleBlockPlacer.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_4633 net/minecraft/world/gen/placer/SimpleBlockPlacer
+	FIELD field_24870 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24871 INSTANCE Lnet/minecraft/class_4633;

--- a/mappings/net/minecraft/world/gen/stateprovider/BlockStateProviderType.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/BlockStateProviderType.mapping
@@ -4,4 +4,5 @@ CLASS net/minecraft/class_4652 net/minecraft/world/gen/stateprovider/BlockStateP
 		ARG 1 codec
 	METHOD method_23457 register (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/class_4652;
 		ARG 0 id
+		ARG 1 codec
 	METHOD method_28863 getCodec ()Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_4656 net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider
 	FIELD field_21314 state Lnet/minecraft/class_2680;
 	FIELD field_24945 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lnet/minecraft/class_2680;)V
+		ARG 1 state

--- a/mappings/net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider.mapping
@@ -6,3 +6,5 @@ CLASS net/minecraft/class_4657 net/minecraft/world/gen/stateprovider/WeightedBlo
 	METHOD method_23458 addState (Lnet/minecraft/class_2680;I)Lnet/minecraft/class_4657;
 		ARG 1 state
 		ARG 2 weight
+	METHOD method_28868 wrap (Lnet/minecraft/class_4131;)Lcom/mojang/serialization/DataResult;
+		ARG 0 states

--- a/mappings/net/minecraft/world/gen/surfacebuilder/AbstractNetherSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/AbstractNetherSurfaceBuilder.mapping
@@ -1,1 +1,11 @@
 CLASS net/minecraft/class_5164 net/minecraft/world/gen/surfacebuilder/AbstractNetherSurfaceBuilder
+	FIELD field_23920 seed J
+	FIELD field_23921 surfaceNoices Lcom/google/common/collect/ImmutableMap;
+	FIELD field_23922 underLavaNoises Lcom/google/common/collect/ImmutableMap;
+	FIELD field_23923 shoreNoise Lnet/minecraft/class_3537;
+	METHOD method_27129 getSurfaceStates ()Lcom/google/common/collect/ImmutableList;
+	METHOD method_27131 createNoisesForStates (Lcom/google/common/collect/ImmutableList;J)Lcom/google/common/collect/ImmutableMap;
+		ARG 0 blockStates
+		ARG 1 seed
+	METHOD method_27133 getUnderLavaStates ()Lcom/google/common/collect/ImmutableList;
+	METHOD method_27135 getLavaShoreState ()Lnet/minecraft/class_2680;

--- a/mappings/net/minecraft/world/gen/surfacebuilder/BasaltDeltasSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/BasaltDeltasSurfaceBuilder.mapping
@@ -2,3 +2,5 @@ CLASS net/minecraft/class_5163 net/minecraft/world/gen/surfacebuilder/BasaltDelt
 	FIELD field_23915 BASALT Lnet/minecraft/class_2680;
 	FIELD field_23916 BLACKSTONE Lnet/minecraft/class_2680;
 	FIELD field_23917 GRAVEL Lnet/minecraft/class_2680;
+	FIELD field_23918 SURFACE_STATES Lcom/google/common/collect/ImmutableList;
+	FIELD field_23919 UNDER_LAVA_STATES Lcom/google/common/collect/ImmutableList;

--- a/mappings/net/minecraft/world/gen/surfacebuilder/ConfiguredSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/ConfiguredSurfaceBuilder.mapping
@@ -1,15 +1,22 @@
 CLASS net/minecraft/class_3504 net/minecraft/world/gen/surfacebuilder/ConfiguredSurfaceBuilder
 	FIELD field_15610 surfaceBuilder Lnet/minecraft/class_3523;
 	FIELD field_15611 config Lnet/minecraft/class_3531;
+	FIELD field_25015 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_3523;Lnet/minecraft/class_3531;)V
 		ARG 1 surfaceBuilder
+		ARG 2 config
 	METHOD method_15197 getConfig ()Lnet/minecraft/class_3531;
 	METHOD method_15198 generate (Ljava/util/Random;Lnet/minecraft/class_2791;Lnet/minecraft/class_1959;IIIDLnet/minecraft/class_2680;Lnet/minecraft/class_2680;IJ)V
 		ARG 1 random
 		ARG 2 chunk
 		ARG 3 biome
+		ARG 4 x
+		ARG 5 z
+		ARG 6 height
+		ARG 7 noise
 		ARG 9 defaultBlock
 		ARG 10 defaultFluid
+		ARG 11 seaLevel
 		ARG 12 seed
 	METHOD method_15199 initSeed (J)V
 		ARG 1 seed

--- a/mappings/net/minecraft/world/gen/surfacebuilder/FrozenOceanSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/FrozenOceanSurfaceBuilder.mapping
@@ -3,5 +3,7 @@ CLASS net/minecraft/class_3512 net/minecraft/world/gen/surfacebuilder/FrozenOcea
 	FIELD field_15639 ICE Lnet/minecraft/class_2680;
 	FIELD field_15640 PACKED_ICE Lnet/minecraft/class_2680;
 	FIELD field_15641 seed J
+	FIELD field_15642 icebergRoofNoise Lnet/minecraft/class_3543;
 	FIELD field_15643 AIR Lnet/minecraft/class_2680;
+	FIELD field_15644 icebergNoise Lnet/minecraft/class_3543;
 	FIELD field_15645 SNOW_BLOCK Lnet/minecraft/class_2680;

--- a/mappings/net/minecraft/world/gen/surfacebuilder/NetherForestSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/NetherForestSurfaceBuilder.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_4789 net/minecraft/world/gen/surfacebuilder/NetherForestSurfaceBuilder
 	FIELD field_22201 seed J
 	FIELD field_22202 CAVE_AIR Lnet/minecraft/class_2680;
+	FIELD field_22203 surfaceNoise Lnet/minecraft/class_3537;

--- a/mappings/net/minecraft/world/gen/surfacebuilder/SoulSandValleySurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/SoulSandValleySurfaceBuilder.mapping
@@ -2,3 +2,4 @@ CLASS net/minecraft/class_4790 net/minecraft/world/gen/surfacebuilder/SoulSandVa
 	FIELD field_22204 GRAVEL Lnet/minecraft/class_2680;
 	FIELD field_22209 SOUL_SAND Lnet/minecraft/class_2680;
 	FIELD field_22210 SOUL_SOIL Lnet/minecraft/class_2680;
+	FIELD field_23924 SURFACE_STATES Lcom/google/common/collect/ImmutableList;

--- a/mappings/net/minecraft/world/gen/surfacebuilder/SurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/SurfaceBuilder.mapping
@@ -38,6 +38,9 @@ CLASS net/minecraft/class_3523 net/minecraft/world/gen/surfacebuilder/SurfaceBui
 	FIELD field_23927 BLACKSTONE Lnet/minecraft/class_2680;
 	FIELD field_23928 BASALT Lnet/minecraft/class_2680;
 	FIELD field_23929 MAGMA_BLOCK Lnet/minecraft/class_2680;
+	FIELD field_25016 codec Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lcom/mojang/serialization/Codec;)V
+		ARG 1 codec
 	METHOD method_15305 generate (Ljava/util/Random;Lnet/minecraft/class_2791;Lnet/minecraft/class_1959;IIIDLnet/minecraft/class_2680;Lnet/minecraft/class_2680;IJLnet/minecraft/class_3531;)V
 		ARG 1 random
 		ARG 2 chunk
@@ -54,3 +57,6 @@ CLASS net/minecraft/class_3523 net/minecraft/world/gen/surfacebuilder/SurfaceBui
 	METHOD method_15306 initSeed (J)V
 		ARG 1 seed
 	METHOD method_15307 register (Ljava/lang/String;Lnet/minecraft/class_3523;)Lnet/minecraft/class_3523;
+		ARG 0 id
+		ARG 1 entry
+	METHOD method_29003 configuredCodec ()Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/world/gen/trunk/GiantTrunkPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/trunk/GiantTrunkPlacer.mapping
@@ -1,2 +1,12 @@
 CLASS net/minecraft/class_5214 net/minecraft/world/gen/trunk/GiantTrunkPlacer
 	FIELD field_24969 CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_27399 setLog (Lnet/minecraft/class_3747;Ljava/util/Random;Lnet/minecraft/class_2338$class_2339;Ljava/util/Set;Lnet/minecraft/class_3341;Lnet/minecraft/class_4643;Lnet/minecraft/class_2338;III)V
+		ARG 0 world
+		ARG 1 random
+		ARG 2 pos
+		ARG 4 boundingBox
+		ARG 5 config
+		ARG 6 newPos
+		ARG 7 x
+		ARG 8 y
+		ARG 9 z

--- a/mappings/net/minecraft/world/gen/trunk/LargeOakTrunkPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/trunk/LargeOakTrunkPlacer.mapping
@@ -5,21 +5,26 @@ CLASS net/minecraft/class_5212 net/minecraft/world/gen/trunk/LargeOakTrunkPlacer
 		ARG 2 height
 	METHOD method_27392 makeBranches (Lnet/minecraft/class_3747;Ljava/util/Random;ILnet/minecraft/class_2338;Ljava/util/List;Ljava/util/Set;Lnet/minecraft/class_3341;Lnet/minecraft/class_4643;)V
 		ARG 1 world
+		ARG 2 random
 		ARG 3 treeHeight
 		ARG 4 treePos
 		ARG 5 branches
+		ARG 7 boundingBox
 		ARG 8 config
 	METHOD method_27393 makeOrCheckBranch (Lnet/minecraft/class_3747;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;ZLjava/util/Set;Lnet/minecraft/class_3341;Lnet/minecraft/class_4643;)Z
 		ARG 1 world
+		ARG 2 random
 		ARG 3 start
 		ARG 4 end
 		ARG 5 make
+		ARG 7 boundingBox
 		ARG 8 config
 	METHOD method_27394 getLongestSide (Lnet/minecraft/class_2338;)I
 		ARG 1 offset
 	METHOD method_27395 getLogAxis (Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2350$class_2351;
 		ARG 1 branchStart
 		ARG 2 branchEnd
+	METHOD method_27396 shouldGenerateBranch (II)F
 	CLASS class_5213 BranchPosition
 		FIELD field_24169 node Lnet/minecraft/class_4647$class_5208;
 		FIELD field_24170 endY I

--- a/mappings/net/minecraft/world/gen/trunk/TrunkPlacer.mapping
+++ b/mappings/net/minecraft/world/gen/trunk/TrunkPlacer.mapping
@@ -13,6 +13,32 @@ CLASS net/minecraft/class_5141 net/minecraft/world/gen/trunk/TrunkPlacer
 		ARG 2 random
 		ARG 3 trunkHeight
 		ARG 4 pos
+		ARG 6 boundingBox
+		ARG 7 config
 	METHOD method_26993 getHeight (Ljava/util/Random;)I
 		ARG 1 random
+	METHOD method_27400 setToDirt (Lnet/minecraft/class_3747;Lnet/minecraft/class_2338;)V
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_27401 trySetState (Lnet/minecraft/class_3747;Ljava/util/Random;Lnet/minecraft/class_2338$class_2339;Ljava/util/Set;Lnet/minecraft/class_3341;Lnet/minecraft/class_4643;)V
+		ARG 0 world
+		ARG 1 random
+		ARG 2 pos
+		ARG 4 boundingBox
+		ARG 5 config
+	METHOD method_27402 getAndSetState (Lnet/minecraft/class_3747;Ljava/util/Random;Lnet/minecraft/class_2338;Ljava/util/Set;Lnet/minecraft/class_3341;Lnet/minecraft/class_4643;)Z
+		ARG 0 world
+		ARG 1 random
+		ARG 2 pos
+		ARG 4 boundingBox
+		ARG 5 config
+	METHOD method_27403 canGenerate (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_27404 setBlockState (Lnet/minecraft/class_1945;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3341;)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state
+		ARG 3 boundingBox
 	METHOD method_28903 getType ()Lnet/minecraft/class_5142;
+	METHOD method_28904 fillTrunkPlacerFields (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P3;

--- a/mappings/net/minecraft/world/gen/trunk/TrunkPlacerType.mapping
+++ b/mappings/net/minecraft/world/gen/trunk/TrunkPlacerType.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_5142 net/minecraft/world/gen/trunk/TrunkPlacerType
 	FIELD field_24973 codec Lcom/mojang/serialization/Codec;
+	METHOD <init> (Lcom/mojang/serialization/Codec;)V
+		ARG 1 codec
 	METHOD method_26995 register (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/class_5142;
 		ARG 0 id
+		ARG 1 codec
 	METHOD method_28908 getCodec ()Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/world/level/LevelInfo.mapping
+++ b/mappings/net/minecraft/world/level/LevelInfo.mapping
@@ -5,11 +5,11 @@ CLASS net/minecraft/class_1940 net/minecraft/world/level/LevelInfo
 	FIELD field_25403 datapackSettings Lnet/minecraft/class_5359;
 	FIELD field_9257 gameMode Lnet/minecraft/class_1934;
 	FIELD field_9261 allowedCommands Z
-	FIELD field_9262 structures Z
+	FIELD field_9262 hardcore Z
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_1934;ZLnet/minecraft/class_1267;ZLnet/minecraft/class_1928;Lnet/minecraft/class_5359;)V
 		ARG 1 name
 		ARG 2 gameMode
-		ARG 3 structures
+		ARG 3 hardcore
 		ARG 4 difficulty
 		ARG 5 allowedCommands
 		ARG 6 gameRules
@@ -22,6 +22,7 @@ CLASS net/minecraft/class_1940 net/minecraft/world/level/LevelInfo
 	METHOD method_28382 withGameMode (Lnet/minecraft/class_1934;)Lnet/minecraft/class_1940;
 		ARG 1 gameMode
 	METHOD method_28383 fromDynamic (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_5359;)Lnet/minecraft/class_1940;
+		ARG 0 dynamic
 		ARG 1 datapackSettings
 	METHOD method_28385 withCopiedGameRules ()Lnet/minecraft/class_1940;
 	METHOD method_29557 withDataPackSettings (Lnet/minecraft/class_5359;)Lnet/minecraft/class_1940;
@@ -29,4 +30,4 @@ CLASS net/minecraft/class_1940 net/minecraft/world/level/LevelInfo
 	METHOD method_29558 getDatapackSettings ()Lnet/minecraft/class_5359;
 	METHOD method_8574 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_8582 areCommandsAllowed ()Z
-	METHOD method_8583 hasStructures ()Z
+	METHOD method_8583 isHardcore ()Z

--- a/mappings/net/minecraft/world/level/LevelProperties.mapping
+++ b/mappings/net/minecraft/world/level/LevelProperties.mapping
@@ -25,6 +25,10 @@ CLASS net/minecraft/class_31 net/minecraft/world/level/LevelProperties
 	FIELD field_21838 modded Z
 	FIELD field_24193 worldBorder Lnet/minecraft/class_2784$class_5200;
 	FIELD field_25029 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_25030 levelInfo Lnet/minecraft/class_1940;
+	FIELD field_25031 dragonFight Lnet/minecraft/class_2487;
+	FIELD field_25425 generatorOptions Lnet/minecraft/class_5285;
+	FIELD field_25426 lifecycle Lcom/mojang/serialization/Lifecycle;
 	METHOD <init> (Lcom/mojang/datafixers/DataFixer;ILnet/minecraft/class_2487;ZIIIJJIIIZIZZZLnet/minecraft/class_2784$class_5200;IILjava/util/UUID;Ljava/util/LinkedHashSet;Lnet/minecraft/class_236;Lnet/minecraft/class_2487;Lnet/minecraft/class_2487;Lnet/minecraft/class_1940;Lnet/minecraft/class_5285;Lcom/mojang/serialization/Lifecycle;)V
 		ARG 1 dataFixer
 		ARG 2 dataVersion
@@ -48,5 +52,22 @@ CLASS net/minecraft/class_31 net/minecraft/world/level/LevelProperties
 		ARG 22 wanderingTraderSpawnChance
 		ARG 23 wanderingTraderId
 		ARG 24 serverBrands
+		ARG 25 scheduledEvents
+		ARG 26 customBossEvents
+		ARG 27 dragonFight
+		ARG 28 levelInfo
+		ARG 29 generatorOptions
+		ARG 30 lifecycle
+	METHOD <init> (Lnet/minecraft/class_1940;Lnet/minecraft/class_5285;Lcom/mojang/serialization/Lifecycle;)V
+		ARG 1 levelInfo
+		ARG 2 generatorOptions
+		ARG 3 lifecycle
 	METHOD method_158 updateProperties (Lnet/minecraft/class_5318;Lnet/minecraft/class_2487;Lnet/minecraft/class_2487;)V
 	METHOD method_185 loadPlayerData ()V
+	METHOD method_29029 readProperties (Lcom/mojang/serialization/Dynamic;Lcom/mojang/datafixers/DataFixer;ILnet/minecraft/class_2487;Lnet/minecraft/class_1940;Lnet/minecraft/class_5315;Lnet/minecraft/class_5285;Lcom/mojang/serialization/Lifecycle;)Lnet/minecraft/class_31;
+		ARG 0 dynamic
+		ARG 1 dataFixer
+		ARG 3 tag
+		ARG 4 levelInfo
+		ARG 6 generatorOptions
+		ARG 7 lifecycle

--- a/mappings/net/minecraft/world/level/UnmodifiableLevelProperties.mapping
+++ b/mappings/net/minecraft/world/level/UnmodifiableLevelProperties.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_27 net/minecraft/world/level/UnmodifiableLevelProperties
 	FIELD field_139 properties Lnet/minecraft/class_5268;
+	FIELD field_24179 saveProperties Lnet/minecraft/class_5219;
+	METHOD <init> (Lnet/minecraft/class_5219;Lnet/minecraft/class_5268;)V
+		ARG 1 saveProperties
+		ARG 2 properties

--- a/mappings/net/minecraft/world/poi/PointOfInterest.mapping
+++ b/mappings/net/minecraft/world/poi/PointOfInterest.mapping
@@ -20,3 +20,5 @@ CLASS net/minecraft/class_4156 net/minecraft/world/poi/PointOfInterest
 	METHOD method_19140 isOccupied ()Z
 	METHOD method_19141 getPos ()Lnet/minecraft/class_2338;
 	METHOD method_19142 getType ()Lnet/minecraft/class_4158;
+	METHOD method_28359 createCodec (Ljava/lang/Runnable;)Lcom/mojang/serialization/Codec;
+		ARG 0 runnable

--- a/mappings/net/minecraft/world/poi/PointOfInterestSet.mapping
+++ b/mappings/net/minecraft/world/poi/PointOfInterestSet.mapping
@@ -6,6 +6,9 @@ CLASS net/minecraft/class_4157 net/minecraft/world/poi/PointOfInterestSet
 	FIELD field_19226 valid Z
 	METHOD <init> (Ljava/lang/Runnable;)V
 		ARG 1 updateListener
+	METHOD <init> (Ljava/lang/Runnable;ZLjava/util/List;)V
+		ARG 1 updateListener
+		ARG 2 valid
 	METHOD method_19145 remove (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_19146 add (Lnet/minecraft/class_2338;Lnet/minecraft/class_4158;)V
@@ -15,6 +18,7 @@ CLASS net/minecraft/class_4157 net/minecraft/world/poi/PointOfInterestSet
 		ARG 1 pos
 		ARG 2 predicate
 	METHOD method_19150 get (Ljava/util/function/Predicate;Lnet/minecraft/class_4153$class_4155;)Ljava/util/stream/Stream;
+		ARG 2 occupation
 	METHOD method_19153 releaseTicket (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_19154 getType (Lnet/minecraft/class_2338;)Ljava/util/Optional;
@@ -24,3 +28,5 @@ CLASS net/minecraft/class_4157 net/minecraft/world/poi/PointOfInterestSet
 	METHOD method_20353 updatePointsOfInterest (Ljava/util/function/Consumer;)V
 	METHOD method_20395 clear ()V
 	METHOD method_22444 isValid ()Z
+	METHOD method_28364 createCodec (Ljava/lang/Runnable;)Lcom/mojang/serialization/Codec;
+		ARG 0 runnable

--- a/mappings/net/minecraft/world/poi/PointOfInterestType.mapping
+++ b/mappings/net/minecraft/world/poi/PointOfInterestType.mapping
@@ -8,6 +8,8 @@ CLASS net/minecraft/class_4158 net/minecraft/world/poi/PointOfInterestType
 	FIELD field_18850 blockStates Ljava/util/Set;
 	FIELD field_19227 BED_STATES Ljava/util/Set;
 	FIELD field_20298 searchDistance I
+	FIELD field_25162 REGISTERED_STATES Ljava/util/Set;
+	FIELD field_25163 VILLAGER_WORKSTATIONS Ljava/util/function/Supplier;
 	METHOD <init> (Ljava/lang/String;Ljava/util/Set;II)V
 		ARG 1 id
 		ARG 2 blockStates

--- a/mappings/net/minecraft/world/updater/WorldUpdater.mapping
+++ b/mappings/net/minecraft/world/updater/WorldUpdater.mapping
@@ -22,6 +22,7 @@ CLASS net/minecraft/class_1257 net/minecraft/world/updater/WorldUpdater
 		ARG 3 worlds
 		ARG 4 eraseCache
 	METHOD method_17830 getChunkPositions (Lnet/minecraft/class_5321;)Ljava/util/List;
+	METHOD method_28304 getWorlds ()Lcom/google/common/collect/ImmutableSet;
 	METHOD method_5393 getProgress (Lnet/minecraft/class_5321;)F
 	METHOD method_5394 getStatus ()Lnet/minecraft/class_2561;
 	METHOD method_5397 getTotalChunkCount ()I


### PR DESCRIPTION
changed to quilt enigma for vineflower support (tried ornithe enigma but it called the mapped column "feather" instead of "named")
backported a bunch of mappings by just using linkie, used mojmap names if no yarn ones were available (mostly for nether features and that darn iceberg class)
fixed the little hardcore <-> structures issue
mapped a bunch of oft-used classes (strongholdgenerator and createworldscreen among them) and then just started doing random stuff